### PR TITLE
Stabilize the SSD flavor decision.

### DIFF
--- a/Decisions/scs-0110-v1-ssd-flavors.md
+++ b/Decisions/scs-0110-v1-ssd-flavors.md
@@ -1,7 +1,8 @@
 ---
 title: SSD Flavors
 type: Decision Record
-status: Draft
+status: Stable
+stabilized_at: 2023-02-08
 track: IaaS
 enhances: scs-xxxx-v1-flavor-naming.md
 ---


### PR DESCRIPTION
Note: This means that our plan to implement these and require these at a later point in time in our list of mandatory flavors in the flavor-naming-spec.md. The precise time when these will become required is to be determined in a separate discussion. (My current assumption is shortly after R4, i.e. April 2023.)

Signed-off-by: Kurt Garloff <kurt@garloff.de>