### PR TITLE
Update ADR on SSO-Identity-Federation

### DIFF
--- a/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
+++ b/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
@@ -179,11 +179,10 @@ Managers that receive granted Projects can assign users permissions to use the p
 [Zitadel is offering REST APIs](https://zitadel.com/docs/apis/introduction)
 for multiple areas of use and configuration.
 
-In comparison to Keycloak it currently lacks support for the
-[Device Authorization Grant](https://github.com/SovereignCloudStack/issues/issues/221),
+It recently also added support for the [Device Authorization Grant](https://github.com/zitadel/oidc/issues/141),
 which, at time of writing, is a feauture that is relevant
 for SCS to be able use OpenStack CLI and APIs with federated
-identities. Support for this is under active development ([Github issues](https://github.com/zitadel/oidc/issues/141)).
+identities ([Device Authorization Grant](https://github.com/SovereignCloudStack/issues/issues/221)).
 
 Support for consumption of LDAP backends is [currently in development](https://github.com/zitadel/zitadel/issues/4609).
 
@@ -225,10 +224,15 @@ given time. Both considered options seem to be potentially viable, but ultimatel
 a decision should be made, even if there are no strict/strong reasons for
 dismissing either option in particular.
 
-Since Keycloak currently supports the OAuth 2.0 grants that SCS wants to make
-use of (e.g. Device Authorization Grant) and offers additional flexibility
-e.g. by allowing LDAP to be used as backend, the project's current choice
-is Keycloak.
+The project's current choice is Keycloak for the following reasons:
+Keycloak currently supports the OAuth 2.0 grants that SCS wants to make
+use of (e.g. Device Authorization Grant). It is the implementation for
+which integration is currently documented in OpenStack and implemented
+in kolla-ansible. SCS currently deploys Keycloak and the IAM team has
+most hands on expecience with it, e.g. when it comes to colletaral questions
+like how to make TLS and signing certificates available to the IdP that shall
+be used in federation to external domains. Finally, it offers
+additional flexibility e.g. by allowing LDAP to be used as backend.
 
 ## Related Documents
 

--- a/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
+++ b/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
@@ -219,13 +219,15 @@ this should allow customers to manage settings like these in their own IAM.
 
 SCS wants to make use of an IdP as part of the reference implementation.
 To move forward with topics of configuration and mapping of roles in a
-OAuth federated scenario as well as questions of token lifecycles etc across
-the federation stack it makes sense to fokus on one IdP implementation at a
-given time.
+OAuth2 federation scenario as well as questions of token lifecycles etc. across
+the federation stack it makes sense to focus on one IdP implementation at a
+given time. Both considered options seem to be potentially viable, but ultimately,
+a decision should be made, even if there are no strict/strong reasons for
+dismissing either option in particular.
 
 Since Keycloak currently supports the OAuth 2.0 grants that SCS wants to make
 use of (e.g. Device Authorization Grant) and offers additional flexibility
-e.g. by allowing LDAP to be used as backend, the projects current choice
+e.g. by allowing LDAP to be used as backend, the project's current choice
 is Keycloak.
 
 ## Related Documents

--- a/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
+++ b/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
@@ -141,6 +141,8 @@ Keycloak supports several SQL backends through JDBC. Thus
 it can be hooked up to a Postgres Database or to a
 MariaDB/Galera cluster e.g..
 
+As of April 11, 2023, Keycloak joined the CNCF as an incubating project.
+
 #### Zitadel
 
 Zitadel is a newer implementation of an SSO IdP.
@@ -212,6 +214,19 @@ this should allow customers to manage settings like these in their own IAM.
   - What's the benefit?
   - How would we allow SCS operators to choose?
 - Do we need some kind of SWOT analysis to come to a decision?
+
+## Decision
+
+SCS wants to make use of an IdP as part of the reference implementation.
+To move forward with topics of configuration and mapping of roles in a
+OAuth federated scenario as well as questions of token lifecycles etc across
+the federation stack it makes sense to fokus on one IdP implementation at a
+given time.
+
+Since Keycloak currently supports the OAuth 2.0 grants that SCS wants to make
+use of (e.g. Device Authorization Grant) and offers additional flexibility
+e.g. by allowing LDAP to be used as backend, the projects current choice
+is Keycloak.
 
 ## Related Documents
 

--- a/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
+++ b/Standards/scs-0300-v1-requirements-for-sso-identity-federation.md
@@ -184,7 +184,8 @@ which, at time of writing, is a feauture that is relevant
 for SCS to be able use OpenStack CLI and APIs with federated
 identities ([Device Authorization Grant](https://github.com/SovereignCloudStack/issues/issues/221)).
 
-Support for consumption of LDAP backends is [currently in development](https://github.com/zitadel/zitadel/issues/4609).
+Support for consumption of LDAP backends is available since [Zitadel v2.23.0](https://github.com/zitadel/zitadel/releases/tag/v2.23.0)
+(see [this guide](https://zitadel.com/docs/guides/integrate/identity-providers/ldap)).
 
 ZITADEL supported backend databases are CockroachDB and PostgreSQL.
 
@@ -231,8 +232,7 @@ which integration is currently documented in OpenStack and implemented
 in kolla-ansible. SCS currently deploys Keycloak and the IAM team has
 most hands on expecience with it, e.g. when it comes to colletaral questions
 like how to make TLS and signing certificates available to the IdP that shall
-be used in federation to external domains. Finally, it offers
-additional flexibility e.g. by allowing LDAP to be used as backend.
+be used in federation to external domains.
 
 ## Related Documents
 


### PR DESCRIPTION
Update ADR draft to reflect that SCS is currently
fokussing on Keycloak.

resolves SovereignCloudStack/standards/issues/269