### PR TITLE
Image metadata is an approved std since long. Move.

### DIFF
--- a/Standards/scs-0102-v1-image-metadata.md
+++ b/Standards/scs-0102-v1-image-metadata.md
@@ -1,9 +1,10 @@
 ---
-title: SCS Image Metadata Proposal
-version: 2022-09-15-001
-authors: Kurt Garloff, Christian Berendt, Felix Kronlage-Dammers, Mathias Fechner, Ralf Heiringhoff
-effective-date: 2022-10-31
-state: Released (v1.0)
+title: SCS Image Metadata Standard
+type: Standard
+stabilized_at: 2022-10-31
+status: Stable
+track: IaaS
+replaces: Image-Metadata-Spec.md
 ---
 
 ## Motivation
@@ -140,7 +141,7 @@ etc., up to 3 days later is not considered a violation of this policy. So the a 
 from an image with `monthly` update frequency might be 2021-04-14, 2021-05-14, 2021-06-15,
 2021-07-14, 2021-07-27 (hotfix), 2021-08-13 ...
 
-Promises to update the registered public images tpyically depend on upstream image providers
+Promises to update the registered public images typically depend on upstream image providers
 (Linux distributors, OS vendors) keeping their promises to build and provide updated images.
 Failures from upstream are not a reason to claim the cloud provider to be in violation of his
 promises. However, if the provider observes massive upstream failures (which can e.g. cause

--- a/Tests/scs-compatible-test.yaml
+++ b/Tests/scs-compatible-test.yaml
@@ -16,7 +16,7 @@ iaas:
         check_tools:
           - executable: ./iaas/flavor-naming/flavor-names-openstack.py
       - name: Image metadata
-        url: https://raw.githubusercontent.com/SovereignCloudStack/Docs/main/Standards/SCS-0004-v1-image-metadata.md
+        url: https://raw.githubusercontent.com/SovereignCloudStack/standards/blob/main/Standards/scs-0102-v1-image-metadata.md
         condition: mandatory
         check_tools:
           - executable: ./iaas/image-metadata/image-md-check.py
@@ -36,7 +36,7 @@ iaas:
             args: SCS-1V:4:10
             condition: optional
       - name: Image metadata
-        url: https://raw.githubusercontent.com/SovereignCloudStack/Docs/main/Standards/SCS-0004-v1-image-metadata.md
+        url: https://raw.githubusercontent.com/SovereignCloudStack/standards/blob/main/Standards/scs-0102-v1-image-metadata.md
         check_tools:
           - executable: ./iaas/image-metadata/image-md-check.py
             args: -v

--- a/Tests/scs-compatible.yaml
+++ b/Tests/scs-compatible.yaml
@@ -11,7 +11,7 @@ iaas:
           - executable: ./iaas/flavor-naming/flavor-names-openstack.py
             args: "--v1prefer"
       - name: Image metadata
-        url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Drafts/Image-Properties-Spec.md
+        url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0102-v1-image-metadata.md
         check_tools:
           - executable: ./iaas/image-metadata/image-md-check.py
             args: -v
@@ -28,7 +28,7 @@ iaas:
         check_tools:
           - executable: ./iaas/flavor-naming/flavor-names-openstack.py
       - name: Image metadata
-        url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Drafts/Image-Properties-Spec.md
+        url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0102-v1-image-metadata.md
         check_tools:
           - executable: ./iaas/image-metadata/image-md-check.py
             args: -v


### PR DESCRIPTION
The standard existed before the standardization process itself was described and the directory structure was fixed. This resulted in it living in the Drafts directory, which was misleading. Move it to standards and adjust the header fields.