### PR TITLE
Refactor the flavor naming document to make it more readable.

### DIFF
--- a/Standards/scs-0100-v2-flavor-naming.md
+++ b/Standards/scs-0100-v2-flavor-naming.md
@@ -68,10 +68,9 @@ encoding all details) as well as very detailed longer names.
 
 ## Complete Proposal for systematic flavor naming
 
-| Prefix | CPUs & Suffix    | RAM[GiB]        | opt: Disk[GB]&type      | opt: extensions |
-| ------ | ---------------- | --------------- | ----------------------- | ----------------|
-| `SCS-` | N`L/V/T/C`[`i`]` | `-`N[`u`][`o`]` | [`-`[M`x`]N[`n/s/l/p`]] | [`_`EXT]        |
-
+| Prefix | CPUs & Suffix      | RAM[GiB]            | opt: Disk[GB]&type            | opt: extensions |
+| ------ | ------------------ | ------------------- | ----------------------------- | ----------------|
+| `SCS-` | N`L/V/T/C`\[`i`\]` | `-`N\[`u`\]\[`o`\]` | \[`-`\[M`x`\]N\[`n/s/l/p`\]\] | \[`_`EXT\]      |
 
 Note that `N` and `M` are placeholders for numbers here.
 The optional fields are denoted in brackets (and have opt: in the header.
@@ -432,12 +431,12 @@ out when generating the name for comparison. In other words: 0 has a meaning of
 - SCS-2C-4-10n_bms_**z3**
 - SCS-2C-4-10n_bms_**z3**
 - SCS-2C-4-10n_bms_**z3h**
-- SCS-2C-4-10n_bms_**z3hh** <- Bare Metal, intel Ice Lake with > 3.25GHz all core freq
+- SCS-2C-4-10n_bms_**z3hh** <- Bare Metal, Intel Ice Lake with > 3.25GHz all core freq
 
 ### [OPTIONAL] GPU support
 
-`_G`X[N][`-`M[`h`]] indicates a Pass-Through GPU from vendor X of gen N with M compute units / SMs / EUs exposed.
-`_g`X[N][`-`M[`h`]] indicates a vGPU from vendor X of gen N with M compute units / SMs / EUs assigned.
+`_G`X\[N\]\[`-`M\[`h`\]\] indicates a Pass-Through GPU from vendor X of gen N with M compute units / SMs / EUs exposed.
+`_g`X\[N\]\[`-`M\[`h`\]\] indicates a vGPU from vendor X of gen N with M compute units / SMs / EUs assigned.
 
 Note that the vendor letter X is mandatory, generation and compute units are optional.
 

--- a/Standards/scs-0100-v2-flavor-naming.md
+++ b/Standards/scs-0100-v2-flavor-naming.md
@@ -77,8 +77,6 @@ The optional fields are denoted in brackets (and have opt: in the header.
 See below for extensions.
 
 Note that all letters are case-sensitive.
-In case you wonder: Feature indicators are capitalized, modifiers are lower case.
-(An exception is the uppercase -G for a pass-through GPU vs. lowercase -g for vGPU.)
 
 Typical flavor names look like `SCS-4V-16-50` for a flavor with 4vCPUs (with limited
 oversubscription), 16GiB RAM and a 50GB disk (of unspecified type).
@@ -242,8 +240,8 @@ We expect a typical CPU:Mem[GiB] ratio of 1:4.
 | 4:32           | SCS-4V-32, SCS-4V-32-100   |
 | 1:1            | SCS-1L-1, SCS-1L-1-5       |
 
-Note that all vCPUs are oversubscribed — the smallest `1L-1` flavor allows
-for heavy oversubscription (note the `L`), and thus can be offered very
+Note that all vCPUs of SCS standard flavors are oversubscribed — the smallest `1L-1`
+flavor allows for heavy oversubscription (note the `L`), and thus can be offered very
 cheaply — imagine jump hosts ...
 Disks types are not specified (and expected to be n or h typically).
 
@@ -326,24 +324,29 @@ with the same specific features will use the same name for them, thus simplifyin
 life for their customers when consuming these flavors.
 
 Note that there is no need to indicate all details and extra features this way.
-Flavors may always perform better or have better performance than indicated in a name.
+Flavors may always perform better or have more features than indicated in a name.
 Underperformance (CPU suffices `L` or `i` or memory suffices `o` and `u`) on the other
-hand MUST NOT be left out, but these are rare.
+hand MUST be indicated in the name; this happens rarely in practice.
 
-For smaller providers, the ability to differentiate between an AMD Milan and an intel
+For smaller providers, the ability to e.g. differentiate between an AMD Milan and an intel
 IceLake and exposed the slightly different feature set to customers and have slightly
-different price points is often not worth the extra effort and the additional
-fragmentation of the machines (host aggregates) that can offer these flavors and
-live a lower utilization when they want to do capacity management such that running
-out of capacity is very unlikely.
+different price points is often not worth the extra effort. This is because having
+this extra differentiation causes fragmentation of the machines (host aggregates)
+that can offer these flavors, thus resulting in a lower utilization (as the capacity
+management will need to have a certain amount of headroom per machine pool to avoid
+running out of capacity).
 
 Note that it possible for providers to register both the generic short names and the
-longer, more detailed names anda llow them to the same set of machines (host aggregates).
+longer, more detailed names and allow them to use the same set of machines (host aggregates).
 Note that machines (hypervisors) can be part of more than one host aggregate.
 
 The extensions have the format:
 
-```[_hyp][_hwv][_[arch[`N`][h][_[G/g]X[`N`][-`M`[h]]][_ib]```
+\[`_`hyp\]\[`_hwv`\]\[`_`\[arch\[N\]\[`h`\]\[`_`\[`G/g`\]X\[N\]\[`-`M\[`h`\]\]\]\[`_ib`\]
+
+Remember that letters are case-sensitive.
+In case you wonder: Feature indicators are capitalized, modifiers are lower case.
+(An exception is the uppercase -G for a pass-through GPU vs. lowercase -g for vGPU.)
 
 ### [OPTIONAL] Hypervisor
 

--- a/Standards/scs-0100-v2-flavor-naming.md
+++ b/Standards/scs-0100-v2-flavor-naming.md
@@ -554,3 +554,7 @@ members to seek further alignment.
 Getting upstream OpenStack support for flavor aliases would provide more flexibility
 and ease migrations between providers, also providers that don't offer the SCS-
 flavors.
+
+We also would like to see upstream `extra_specs` standardizing the discoverability of some
+properties exposed via the SCS names and work on IaC tooling (terraform ...)
+to make use of these when selecting a flavor.


### PR DESCRIPTION
Main change is to move the complex and rarely used extensions to the bottom of the document and add a section that explains why these exist at all and how they may or may not be used.

The change does not change the specification in any way, thus no new version number is assigned.

This change is in preparation of two decsisions and PRs that will be created:
(1) Reduce the mandated flavors by making the flavors with disks
    only recommended (as discussed on May 8).
(2) Discuss an alternative approach to flavor naming from PS.