### PR TITLE
Revision of scs-0101-v1-entropy

### DIFF
--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -31,15 +31,15 @@ bus timings, or keyboard timings, to name a few.
 
 _More recent methods_ of generating entropy include measuring IRQ jitter
 (available in Linux since kernel 5.4 or, before that, via a daemon such as
-[HavegeD](http://www.issihosts.com/haveged/)) as well as the special CPU
-instructions RDRAND and RDSEED, which are present in all modern CPUs from
-ARM, AMD, and Intel.
+[HavegeD](http://www.issihosts.com/haveged/)) as well as dedicated CPU
+instructions (available in virtually all major CPUs: RDSEED or RDRAND
+on x86_64 and RNDR on arm64).
 
 Finally, a dedicated device can be utilized — if present — that is
 called _hardware random number generator_ or HRNG for short. For instance,
 the [Trusted Platform Module](https://en.wikipedia.org/wiki/Trusted_Platform_Module)
 includes a HRNG. On Linux systems, the HRNG appears as `/dev/hwrng`.
-Note that, while the RDRAND and RDSEED instructions can be construed as
+Note that, while the dedicated CPU instructions can be construed as
 a HRNG, they are not treated as such by the kernel, i.e., they _do not_
 appear as `/dev/hwrng`!
 
@@ -59,7 +59,7 @@ These patches have now also arrived in the upstream LTS images.
 
 Virtual instances or virtual machines do not have the traditional sources
 of entropy mentioned above. However, the more recent methods mentioned
-above do work just fine (RDRAND and RDSEED are not privileged).
+above do work just fine (the CPU instructions are not privileged).
 
 Alternatively, a virtualized HRNG called `virtio-rng` can be established
 that injects entropy from the host into the instance, where this
@@ -117,10 +117,11 @@ The user may choose to use the `virtio-rng` device via `rngd`.
 
 ### Compute nodes
 
-Compute nodes must use CPUs that offer RDRAND/RDSEED, and these
-instructions may not be filtered by the hypervisor. If this requirement
-cannot be verified directly, then at least the following two conditions
-must be satisfied in a virtual instance:
+Compute nodes must use CPUs that offer instructions for accessing
+entropy (such as RDSEED or RDRAND on x86_64 or RNDR on arm64), and
+these instructions may not be filtered by the hypervisor.
+If this requirement cannot be verified directly, then at least the
+following two conditions must be satisfied in a virtual instance:
 
 1. The special file `/proc/sys/kernel/random/entropy_avail` must contain
 the value 256 (pinned since kernel 5.18).

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -37,8 +37,8 @@ ARM, AMD, and Intel, and even in the consumer-grade Raspberry Pi
 (1b onwards).
 
 Finally, a dedicated device can be utilized — if present — that is
-called _hardware random number generator_ or HW RNG for short. For instance,
-the [trusted platform module](https://en.wikipedia.org/wiki/Trusted_Platform_Module)
+called _hardware random number generator_ or HWRNG for short. For instance,
+the [Trusted Platform Module](https://en.wikipedia.org/wiki/Trusted_Platform_Module)
 includes a HW RNG. On Linux systems, the HW RNG appears as `/dev/hwrng`.
 Note that, while the RDRAND/RDSEED instruction set can be construed as
 a HW RNG, it is not treated as such by the kernel, i.e., it _does not_

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -106,12 +106,12 @@ hw_rng:rate_period - Sets the duration of a read period in seconds.
 
 ### Images
 
+Images must activate the attribute `hw_rng_model: virtio`.
+
 The daemon `rngd` must be installed (usually from `rng-tools`
 or `rng-utils`).
 
-Images may activate the attribute `hw_rng_model: virtio`.
-
-The user may then choose to use the `virtio-rng` device via `rngd`.
+The user may choose to use the `virtio-rng` device via `rngd`.
 
 ### Compute nodes
 

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -81,20 +81,21 @@ to enable access to a HRNG.
 ## Motivation
 
 As stated above, good sources of entropy are paramount for many
-important applications. Moreover, current technology makes it easy
-to provide these sources to virtual instances. Therefore, this standard
-mandates that these sources be made available on all conformant clouds.
+important applications. This standard ensures that sufficient entropy
+will be available. In short, this goal is achieved by (a) requiring
+sufficiently recent CPUs in the hosts and kernels in the guests, and
+(b) recommending to provide the means to use `virtio-rng`.
 
 ## Entropy in SCS clouds
 
-This standard does not intend to make any guarantees for linux images
+This standard does not intend to make any guarantees for Linux images
 that are not themselves included in the
-[SCS standard](https://github.com/SovereignCloudStack/standards/blob/main/Standards/scs-0102-v1-image-metadata.md), in particular
-images having a kernel below version 5.18.
+[Image Metadata Standard](https://github.com/SovereignCloudStack/standards/blob/main/Standards/scs-0102-v1-image-metadata.md),
+in particular images having a kernel (patch level) below version 5.18.
 
 ### Flavors
 
-All flavors must have the following attribute activated:
+It is recommended that all flavors have the following attribute:
 
 ```console
 hw_rng:allowed=True
@@ -110,7 +111,7 @@ hw_rng:rate_period - Sets the duration of a read period in seconds.
 
 ### Images
 
-Images must activate the attribute `hw_rng_model: virtio`.
+It is recommended that images activate the attribute `hw_rng_model: virtio`.
 
 The daemon `rngd` must be installed (usually from `rng-tools`
 or `rng-utils`).
@@ -119,8 +120,15 @@ The user may choose to use the `virtio-rng` device via `rngd`.
 
 ### Compute nodes
 
-Compute nodes must use CPUs that offer RDRAND/RDSEED. This requirement
-is both very hard to verify and almost impossible to violate, so it will
-not be tested for.
+Compute nodes must use CPUs that offer RDRAND/RDSEED, and these
+instructions may not be filtered by the hypervisor. If this requirement
+cannot be verified directly, then at least the following two conditions
+must be satisfied:
+
+1. The special file `/proc/sys/kernel/random/entropy_avail` must contain
+the value 256 (pinned since kernel 5.18).
+
+2. The number of FIPS 140-2 failures must not exceed 3 out of 1000 blocks
+tested, as determined by `cat /dev/random | rngtest -c 1000` .
 
 Compute nodes may provide a HRNG via `rngd`.

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -19,35 +19,35 @@ system.
 
 Cryptography is a very prominent, albeit not the only application that
 heavily relies on entropy for operations such as creating secure keys.
-These operations can stall and take an abnormally long amount of time
-when the available _entropy runs out_, leading to malfunctioning OpenSSL
-operations and applications such as load balancers.
+When the available _entropy runs out_, said operations can stall and
+take an abnormally long amount of time, which in turn can lead to
+malfunctions, e.g., with OpenSSL or load balancers.
 
 ### Sources of entropy
 
 In _traditional baremetal systems_ the amount of incertitude is sourced
 from the randomness of the read/write cycles of the disk heads of a disk drive,
-bus timings as well as items such as keyboard timings.
+bus timings, or keyboard timings, to name a few.
 
 _More recent methods_ of generating entropy include measuring IRQ jitter
 (available in Linux since kernel 5.4 or, before that, via a daemon such as
-[HavegeD](http://www.issihosts.com/haveged/)) as well as a special CPU
-instruction set (RDRAND/RDSEED), which is present in all modern CPUs from
+[HavegeD](http://www.issihosts.com/haveged/)) as well as the special CPU
+instructions RDRAND and RDSEED, which are present in all modern CPUs from
 ARM, AMD, and Intel.
 
 Finally, a dedicated device can be utilized — if present — that is
-called _hardware random number generator_ or HWRNG for short. For instance,
+called _hardware random number generator_ or HRNG for short. For instance,
 the [Trusted Platform Module](https://en.wikipedia.org/wiki/Trusted_Platform_Module)
-includes a HW RNG. On Linux systems, the HW RNG appears as `/dev/hwrng`.
-Note that, while the RDRAND/RDSEED instruction set can be construed as
-a HW RNG, it is not treated as such by the kernel, i.e., it _does not_
+includes a HRNG. On Linux systems, the HRNG appears as `/dev/hwrng`.
+Note that, while the RDRAND and RDSEED instructions can be construed as
+a HRNG, they are not treated as such by the kernel, i.e., they _do not_
 appear as `/dev/hwrng`!
 
 The Linux kernel combines multiple sources of entropy into a pool. To this
 end, it will use all of the sources discussed so far with one exception:
-the HW RNG must be fed into the pool (if so desired) via the daemon `rngd`.
+the HWNG must be fed into the pool (if so desired) via the daemon `rngd`.
 The kernel converts the entropy from the pool into cryptographically
-secure random numbers that appear under `/dev/random`.
+secure random numbers that appear under `/dev/random` and `/dev/urandom`.
 
 With kernel 5.18, the algorithm that accomplishes
 said conversion has been drastically improved (see
@@ -59,19 +59,24 @@ These patches have now also arrived in the upstream LTS images.
 
 Virtual instances or virtual machines do not have the traditional sources
 of entropy mentioned above. However, the more recent methods mentioned
-above do work just fine (the RDRAND instruction set is not privileged).
+above do work just fine (RDRAND and RDSEED are not privileged).
 
-Alternatively, a virtualized HW RNG called `virtio-rng` can be established
+Alternatively, a virtualized HRNG called `virtio-rng` can be established
 that injects entropy from the host into the instance, where this
 entropy can be sourced optionally from either the host's `/dev/random` or
-some HW RNG in the host. This virtualized HW RNG behaves just like real
+some HRNG in the host. This virtualized HRNG behaves just like a real
 one, that is, it appears as `/dev/hwrng`, and the daemon `rngd` must
 be used to feed it into the kernel's entropy pool.
+
+On a side note, the kernel exposes available HRNGs via the special
+directory `/sys/devices/virtual/misc/hw_random`. In particular, the
+file `rng_available` lists availabe HRNGs while the file `rng_current`
+contains the HRNG currently used.
 
 In summary, with current kernels and CPUs entropy in virtual instances
 is readily available to a sufficient degree. In addition, the host's
 entropy sources can be injected using `virtio-rng` if so desired, e.g.,
-to enable access to a HW RNG.
+to enable access to a HRNG.
 
 ## Motivation
 
@@ -118,4 +123,4 @@ Compute nodes must use CPUs that offer RDRAND/RDSEED. This requirement
 is both very hard to verify and almost impossible to violate, so it will
 not be tested for.
 
-Compute nodes may provide a true HW RNG via `rngd`.
+Compute nodes may provide a HRNG via `rngd`.

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -123,7 +123,7 @@ The user may choose to use the `virtio-rng` device via `rngd`.
 Compute nodes must use CPUs that offer RDRAND/RDSEED, and these
 instructions may not be filtered by the hypervisor. If this requirement
 cannot be verified directly, then at least the following two conditions
-must be satisfied:
+must be satisfied in a virtual instance:
 
 1. The special file `/proc/sys/kernel/random/entropy_avail` must contain
 the value 256 (pinned since kernel 5.18).

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -33,8 +33,7 @@ _More recent methods_ of generating entropy include measuring IRQ jitter
 (available in Linux since kernel 5.4 or, before that, via a daemon such as
 [HavegeD](http://www.issihosts.com/haveged/)) as well as a special CPU
 instruction set (RDRAND/RDSEED), which is present in all modern CPUs from
-ARM, AMD, and Intel, and even in the consumer-grade Raspberry Pi
-(1b onwards).
+ARM, AMD, and Intel.
 
 Finally, a dedicated device can be utilized — if present — that is
 called _hardware random number generator_ or HWRNG for short. For instance,

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -81,7 +81,12 @@ important applications. Moreover, current technology makes it easy
 to provide these sources to virtual instances. Therefore, this standard
 mandates that these sources be made available on all conformant clouds.
 
-## Entropy in SCS Clouds
+## Entropy in SCS clouds
+
+This standard does not intend to make any guarantees for linux images
+that are not themselves included in the
+[SCS standard](https://github.com/SovereignCloudStack/standards/blob/main/Standards/scs-0102-v1-image-metadata.md), in particular
+images having a kernel below version 5.18.
 
 ### Flavors
 
@@ -107,3 +112,11 @@ or `rng-utils`).
 Images may activate the attribute `hw_rng_model: virtio`.
 
 The user may then choose to use the `virtio-rng` device via `rngd`.
+
+### Compute nodes
+
+Compute nodes must use CPUs that offer RDRAND/RDSEED. This requirement
+is both very hard to verify and almost impossible to violate, so it will
+not be tested for.
+
+Compute nodes may provide a true HW RNG via `rngd`.

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -36,7 +36,7 @@ instruction set (RDRAND/RDSEED), which is present in all modern CPUs from
 ARM, AMD, and Intel, and even in the consumer-grade Raspberry Pi
 (1b onwards).
 
-Finally, a dedicated device can be utilized -- if present -- that is
+Finally, a dedicated device can be utilized — if present — that is
 called _hardware random number generator_ or HW RNG for short. For instance,
 the [trusted platform module](https://en.wikipedia.org/wiki/Trusted_Platform_Module)
 includes a HW RNG. On Linux systems, the HW RNG appears as `/dev/hwrng`.
@@ -51,7 +51,7 @@ The kernel converts the entropy from the pool into cryptographically
 secure random numbers that appear under `/dev/random`.
 
 With kernel 5.18, the algorithm that accomplishes
-said conversion has been drastically improved (see 
+said conversion has been drastically improved (see
 [linux-rng-5.17-18](https://web.archive.org/web/20230321040526/https://www.zx2c4.com/projects/linux-rng-5.17-5.18/)),
 so much so that running out of entropy is virtually ruled out.
 These patches have now also arrived in the upstream LTS images.

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -45,7 +45,7 @@ appear as `/dev/hwrng`!
 
 The Linux kernel combines multiple sources of entropy into a pool. To this
 end, it will use all of the sources discussed so far with one exception:
-the HWNG must be fed into the pool (if so desired) via the daemon `rngd`.
+the HRNG must be fed into the pool (if so desired) via the daemon `rngd`.
 The kernel converts the entropy from the pool into cryptographically
 secure random numbers that appear under `/dev/random` and `/dev/urandom`.
 

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -26,7 +26,7 @@ operations and applications such as load balancers.
 ### Sources of entropy
 
 In _traditional baremetal systems_ the amount of incertitude is sourced
-from the randomness of read/write cycle of the disk heads of a disk drive,
+from the randomness of the read/write cycles of the disk heads of a disk drive,
 bus timings as well as items such as keyboard timings.
 
 _More recent methods_ of generating entropy include measuring IRQ jitter

--- a/Standards/scs-0101-v1-entropy.md
+++ b/Standards/scs-0101-v1-entropy.md
@@ -82,16 +82,9 @@ to enable access to a HRNG.
 
 As stated above, good sources of entropy are paramount for many
 important applications. This standard ensures that sufficient entropy
-will be available. In short, this goal is achieved by (a) requiring
-sufficiently recent CPUs in the hosts and kernels in the guests, and
-(b) recommending to provide the means to use `virtio-rng`.
+will be available in virtual instances.
 
 ## Entropy in SCS clouds
-
-This standard does not intend to make any guarantees for Linux images
-that are not themselves included in the
-[Image Metadata Standard](https://github.com/SovereignCloudStack/standards/blob/main/Standards/scs-0102-v1-image-metadata.md),
-in particular images having a kernel (patch level) below version 5.18.
 
 ### Flavors
 
@@ -110,6 +103,10 @@ hw_rng:rate_period - Sets the duration of a read period in seconds.
 ```
 
 ### Images
+
+It is recommended to use images having a kernel (patch level) version 5.18
+or up. This condition is already satisfied by every mandatory image defined
+in the [Image Metadata Standard](https://github.com/SovereignCloudStack/standards/blob/main/Standards/scs-0102-v1-image-metadata.md).
 
 It is recommended that images activate the attribute `hw_rng_model: virtio`.
 


### PR DESCRIPTION
Hi everyone.

I tried to apply the structure suggested by scs-0001. Besides, I did a kinda deep dive into the topic of entropy, and I revised the draft accordingly. Please have a look.

Most important insights to me:
- linux does not treat RDRAND/RDSEED like a classical hardware rng (it doesn't appear as `/dev/hwrng` and it's automatically part of the entropy pool)
- therefore `rngd` is only required on the host if it does feature a true hw rng
- for the same reason (namely, that linux automatically uses RDRAND), it seems to me that it's mostly up to the user's taste whether they want to use `virtio-rng` 

**edit** just mention https://github.com/SovereignCloudStack/issues/issues/234 to make the connection