### PR TITLE
Renumber metering 0110/0111 to 0410/0411.

### DIFF
--- a/Standards/scs-0410-v1-gnocchi-as-metering-database.md
+++ b/Standards/scs-0410-v1-gnocchi-as-metering-database.md
@@ -2,7 +2,7 @@
 title: Gnocchi as database for metering
 type: Decision Record
 status: Draft
-track: IaaS
+track: Ops
 ---
 
 <!-- This file uses semantic linebreaks. See <https://sembr.org/> for more info. -->
@@ -156,7 +156,7 @@ let alone rolling a custom implementation.
 
 ## Related Documents
 
-- SCS-0111-v1
+- SCS-0411-v1
 
 ## Conformance Tests
 

--- a/Standards/scs-0411-v1-publishing_method_for_metering_data.md
+++ b/Standards/scs-0411-v1-publishing_method_for_metering_data.md
@@ -2,7 +2,7 @@
 title: Push-based approach for providing usage data
 type: Decision Record
 status: Draft
-track: IaaS
+track: Ops
 ---
 
 <!-- This file uses semantic linebreaks. See <https://sembr.org/> for more info. -->
@@ -99,7 +99,7 @@ or alternatively poll in the highest change frequency ever expected.
 
 ## Related Documents
 
-- SCS-0110-v1
+- SCS-0410-v1
 
 ## Conformance Tests
 


### PR DESCRIPTION
This put it into the Ops track -- the metering approach is not restricted to the IaaS layer, even if we implement it there first.

This also avoids the conflict with the previously existent scs-0110-v1-ssd-flavors.
(Note that we don't want to have double numbers, not even between decisions and standards.)