### PR TITLE
Domain Manager role standard (issues#184)

### DIFF
--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -56,14 +56,14 @@ To address this, this standard defines a new Domain Manager role in conjunction 
 
 - the Domain Manager role MUST support managing projects, groups and users within a specific domain
 - the Domain Manager role MUST be properly scoped to a domain, it MUST NOT gain access to resources outside of its owning domain
-- the Domain Manager role MUST NOT enable customers to manipulate existing roles or create new roles
-- the Domain Manager role MUST only allow customers to assign specific non-administrative roles to their managed users, Domain Managers MUST NOT be able to abuse the role assignment functionalities to escalate their own privileges or those of other users
+- the Domain Manager role MUST NOT be able to manipulate existing roles or create new roles
+- the Domain Manager role MUST only be allowed to assign specific non-administrative roles to their managed users, Domain Managers MUST NOT be able to abuse the role assignment functionalities to escalate their own privileges or those of other users
 
 ### Options considered
 
 #### Re-using the existing `admin` role
 
-As role assigments can be scoped to project, groups and domains the most obvious option would be to assign the existing `admin` role to users representing Domain Managers in a scoped fashion.
+As role assignments can be scoped to project, groups and domains the most obvious option would be to assign the existing `admin` role to users representing Domain Managers in a scoped fashion.
 
 However, due to architectural limitations[^2] of the existing OpenStack implementation of roles, the `admin` role has a special meaning reaching beyond the RBAC checks done by Keystone and other OpenStack components.
 This results in special permissions being granted to users possessing the role which ignore the project or domain scope of the role assignment.

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -1,0 +1,167 @@
+---
+title: Domain Manager configuration for Keystone
+type: Standard
+status: Draft
+track: IAM
+---
+
+## Introduction
+
+SCS Clouds should provide a way to grant Domain Manager rights to SCS Customers which provides IAM self-service capabilities within an OpenStack domain.
+This is not properly implemented in the default OpenStack configuration and requires specific adjustments to the Keystone identity management configuration.
+To avoid conflict with the unscoped `admin` role in OpenStack we want to refer to this new role as "Domain Manager" (`domain-manager`).
+
+### Glossary
+
+The following special terms are used throughout this standard document:
+
+| Term | Meaning |
+|---|---|
+| RBAC | Role-Based Access Control[^1] established by OpenStack Keystone |
+| project | OpenStack project as per Keystone RBAC |
+| user | OpenStack user as per Keystone RBAC |
+| group | OpenStack group as per Keystone RBAC |
+| role | OpenStack role as per Keystone RBAC |
+| domain | OpenStack domain as per Keystone RBAC |
+| IAM | identity and access management |
+| IAM resources | projects, users, groups, roles, domains as managed by OpenStack Keystone |
+| cloud admin | OpenStack user belonging to the cloud provider that possesses the `admin` role |
+
+[^1]: https://static.opendev.org/docs/patrole/latest/rbac-overview.html
+
+### Impact
+
+Applying this standard modifies the API policy configuration of Keystone and introduces a new global role to Keystone to enable IAM self-service for customers within a domain.
+This IAM self-service allows special Domain Manager users within a domain to manage users, project, groups and role assignments.
+
+The provisioning of such self-service capabilities using the new role works on a per-tenant (customer domain) basis and is up to the cloud provider, thus entirely optional.
+Omitting the provisioning of Domain Manager users for customers will result in an OpenStack cloud that behaves identically to a configuration without the standard applied.
+
+## Motivation
+
+In the default configuration of Keystone, only users with the `admin` role may manage the IAM resources such as projects, groups and users and their relation through role assignments.
+The `admin` role in OpenStack Keystone is not properly scoped when assigned within a domain or project only as due to hard-coded architectural limitations in OpenStack, a user with the `admin` role may escalate their privileges outside of their assigned project or domain boundaries.
+Thus, it is not possible to properly give customers a self-service functionality in regards to project, group and user management with the default configuration.
+
+To address this, this standard defines a new Domain Manager role in conjunction with appropriate Keystone API policy adjustments to establish a standardized extension to the default Keystone configuration allowing for IAM self-service capabilities for customers within domains.
+
+### Desired Workflow
+
+1. The cloud admin creates the desired domains for the customers for which IAM self-service capabilities are desired.
+2. The cloud admin creates one or more users within each of the applicable domains and assigns the Domain Manager role to them. These users represent the Domain Managers of the corresponding domain.
+3. The customer uses the Domain Manager users to manage (create, update, delete) users, projects, groups and corresponding role assignments within their domain.
+
+## Design Considerations
+
+- the Domain Manager role MUST support managing projects, groups and users within a specific domain
+- the Domain Manager role MUST be properly scoped to a domain, it MUST NOT gain access to resources outside of its owning domain
+- the Domain Manager role MUST NOT enable customers to manipulate existing roles or create new roles
+- the Domain Manager role MUST only allow customers to assign specific non-administrative roles to their managed users, Domain Managers MUST NOT be able to abuse the role assignment functionalities to escalate their own privileges or those of other users
+
+### Options considered
+
+#### Re-using the existing `admin` role
+
+As role assigments can be scoped to project, groups and domains the most obvious option would be to assign the existing `admin` role to users representing Domain Managers in a scoped fashion.
+
+However, due to architectural limitations[^2] of the existing OpenStack implementation of roles, the `admin` role has a special meaning reaching beyond the RBAC checks done by Keystone and other OpenStack components.
+This results in special permissions being granted to users possessing the role which ignore the project or domain scope of the role assignment.
+This poses severe security risks as the proper scoping of the `admin` role is impossible.
+**Due to this, this approach was discarded early.**
+
+[^2]: https://bugs.launchpad.net/keystone/+bug/968696
+
+#### Introducing a new role and API policy changes
+
+OpenStack Keystone allows for new roles to be created via its API by administrative users.
+Additionally, each OpenStack API's RBAC can be adjusted through an API policy file (`policy.yaml`) through olso-policy[^3], Keystone included.
+The possibility of managing users, projects, role assignments and so on is regulated through Keystone's RBAC configured by its API policy file.
+
+This means that by creating a new role and extending Keystone's API policy configuration a new Domain Manager role can be established that is limited to a specific subset of the Keystone API to be used to manage users, projects and role assignments within a domain.
+
+[^3]: https://docs.openstack.org/oslo.policy/latest/admin/index.html
+
+## Open questions
+
+### Limitations
+
+The approach described in this standard imposes the following limitations:
+
+1. as a result of the "`identity:list_domains`" rule (see below), Domain Managers are able to see all domains via "`openstack domain list`" and can inspect the metadata of other domains with "`openstack domain show`"
+2. as a result of the "`identity:list_roles`" rule (see below), Domain Managers are able to see all roles via "`openstack role list`" and can inspect the metadata of other roles with "`openstack role show`"
+
+**The result of points 1 and 2 is that the metadata of all domains and roles will be exposed to all Domain Managers!**
+
+## Decision
+
+A role named "`domain-manager`" is to be created via the Keystone API and the policy adjustments quoted below are to be applied.
+
+### Policy adjustments
+
+```yaml
+# classify domain managers with a special role
+"is_domain_manager": "role:domain-manager"
+
+# specify a rule that whitelists roles which domain admins are permitted
+# to assign and revoke within their domain
+"is_domain_managed_role": "%(target.role.name)s:member"
+
+# allow domain admins to retrieve their own domain
+"identity:get_domain": "(rule:is_domain_manager and token.domain.id:%(target.domain.id)s) or rule:admin_required"
+
+# list_domains is needed for GET /v3/domains?name=... requests
+# this is mandatory for things like
+# `create user --domain $DOMAIN_NAME $USER_NAME` to correctly discover
+# domains by name
+"identity:list_domains": "rule:is_domain_manager or rule:admin_required"
+
+# list_roles is needed for GET /v3/roles?name=... requests
+# this is mandatory for things like `role add ... $ROLE_NAME`` to correctly
+# discover roles by name
+"identity:list_roles": "rule:is_domain_manager or rule:admin_required"
+
+# allow domain admins to manage users within their domain
+"identity:list_users": "(rule:is_domain_manager and token.domain.id:%(target.domain_id)s) or rule:admin_required"
+"identity:get_user": "(rule:is_domain_manager and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+"identity:create_user": "(rule:is_domain_manager and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+"identity:update_user": "(rule:is_domain_manager and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+"identity:delete_user": "(rule:is_domain_manager and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+
+# allow domain admins to manage projects within their domain
+"identity:list_projects": "(rule:is_domain_manager and token.domain.id:%(target.domain_id)s) or rule:admin_required"
+"identity:get_project": "(rule:is_domain_manager and token.domain.id:%(target.project.domain_id)s) or rule:admin_required"
+"identity:create_project": "(rule:is_domain_manager and token.domain.id:%(target.project.domain_id)s) or rule:admin_required"
+"identity:update_project": "(rule:is_domain_manager and token.domain.id:%(target.project.domain_id)s) or rule:admin_required"
+"identity:delete_project": "(rule:is_domain_manager and token.domain.id:%(target.project.domain_id)s) or rule:admin_required"
+
+# allow domain managers to manage role assignments within their domain
+# (restricted to specific roles by the 'is_domain_managed_role' rule)
+"is_domain_user_project_grant": "token.domain.id:%(target.user.domain_id)s and token.domain.id:%(target.project.domain_id)s and rule:is_domain_managed_role"
+"is_domain_group_project_grant": "token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.project.domain_id)s and rule:is_domain_managed_role"
+"domain_manager_grant": "rule:is_domain_manager and (rule:is_domain_user_project_grant or rule:is_domain_group_project_grant)"
+"identity:check_grant": "rule:domain_manager_grant or rule:admin_required"
+"identity:list_grants": "rule:domain_manager_grant or rule:admin_required"
+"identity:create_grant": "rule:domain_manager_grant or rule:admin_required"
+"identity:revoke_grant": "rule:domain_manager_grant or rule:admin_required"
+"identity:list_role_assignments": "(rule:is_domain_manager and token.domain.id:%(target.domain_id)s) or rule:admin_required"
+
+# allow domain managers to manage groups within their domain
+"identity:list_groups": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s) or rule:admin_required"
+"identity:get_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s) or rule:admin_required"
+"identity:create_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s) or rule:admin_required"
+"identity:update_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s) or rule:admin_required"
+"identity:delete_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s) or rule:admin_required"
+"identity:list_groups_for_user": "(rule:is_domain_manager and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+"identity:list_users_in_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s) or rule:admin_required"
+"identity:remove_user_from_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+"identity:check_user_in_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+"identity:add_user_to_group": "(rule:is_domain_manager and token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
+```
+
+## Related Documents
+
+Related Documents, OPTIONAL
+
+## Conformance Tests
+
+Conformance Tests, OPTIONAL

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -27,7 +27,7 @@ The following special terms are used throughout this standard document:
 | IAM resources | projects, users, groups, roles, domains as managed by OpenStack Keystone |
 | cloud admin | OpenStack user belonging to the cloud provider that possesses the `admin` role |
 
-[^1]: https://static.opendev.org/docs/patrole/latest/rbac-overview.html
+[^1]: [OpenStack Documentation: Role-Based Access Control Overview](https://static.opendev.org/docs/patrole/latest/rbac-overview.html)
 
 ### Impact
 
@@ -69,7 +69,7 @@ This results in special permissions being granted to users possessing the role w
 This poses severe security risks as the proper scoping of the `admin` role is impossible.
 **Due to this, this approach was discarded early.**
 
-[^2]: https://bugs.launchpad.net/keystone/+bug/968696
+[^2]: [Launchpad bug: "admin"-ness not properly scoped](https://bugs.launchpad.net/keystone/+bug/968696)
 
 #### Introducing a new role and API policy changes
 
@@ -79,7 +79,7 @@ The possibility of managing users, projects, role assignments and so on is regul
 
 This means that by creating a new role and extending Keystone's API policy configuration a new Domain Manager role can be established that is limited to a specific subset of the Keystone API to be used to manage users, projects and role assignments within a domain.
 
-[^3]: https://docs.openstack.org/oslo.policy/latest/admin/index.html
+[^3]: [OpenStack Documentation: Administering Applications that use oslo.policy](https://docs.openstack.org/oslo.policy/latest/admin/index.html)
 
 ## Open questions
 
@@ -165,14 +165,14 @@ A role named "`domain-manager`" is to be created via the Keystone API and the po
 **Description:** Upstream bug report about the underlying architectural issue of the `admin` role not being properly scoped and giving system-level admin permissions regardless of whether the `admin` role assignment was scoped to project or domain level.
 This is the main reason for the `admin` role being inappropriate to implement Domain Managers.
 
-**Link:** https://bugs.launchpad.net/keystone/+bug/968696
+**Link:** [Launchpad bug: "admin"-ness not properly scoped](https://bugs.launchpad.net/keystone/+bug/968696)
 
 ### Consistent and Secure Default RBAC
 
 **Description:** Upstream rework of the default role definitions and hierarchy across all OpenStack services.
 Aims to introduce support for a scoped `manager` role by 2024 but only focuses on project-level scoping for this role so far, not domain-level.
 
-**Link:** https://governance.openstack.org/tc/goals/selected/consistent-and-secure-rbac.html
+**Link:** [OpenStack Technical Committee Governance Documents: Consistent and Secure Default RBAC](https://governance.openstack.org/tc/goals/selected/consistent-and-secure-rbac.html)
 
 ## Conformance Tests
 

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -120,6 +120,11 @@ A role named "`domain-manager`" is to be created via the Keystone API and the po
 # discover roles by name
 "identity:list_roles": "rule:is_domain_manager or rule:admin_required"
 
+# get_role is needed for GET /v3/roles/{role_id} requests
+# this is mandatory for the OpenStack SDK to properly process role assignments
+# which are issued by role id instead of name
+"identity:get_role": "(rule:is_domain_manager and rule:is_domain_managed_role) or rule:admin_required"
+
 # allow domain admins to manage users within their domain
 "identity:list_users": "(rule:is_domain_manager and token.domain.id:%(target.domain_id)s) or rule:admin_required"
 "identity:get_user": "(rule:is_domain_manager and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -160,7 +160,19 @@ A role named "`domain-manager`" is to be created via the Keystone API and the po
 
 ## Related Documents
 
-Related Documents, OPTIONAL
+### "admin"-ness not properly scoped
+
+**Description:** Upstream bug report about the underlying architectural issue of the `admin` role not being properly scoped and giving system-level admin permissions regardless of whether the `admin` role assignment was scoped to project or domain level.
+This is the main reason for the `admin` role being inappropriate to implement Domain Managers.
+
+**Link:** https://bugs.launchpad.net/keystone/+bug/968696
+
+### Consistent and Secure Default RBAC
+
+**Description:** Upstream rework of the default role definitions and hierarchy across all OpenStack services.
+Aims to introduce support for a scoped `manager` role by 2024 but only focuses on project-level scoping for this role so far, not domain-level.
+
+**Link:** https://governance.openstack.org/tc/goals/selected/consistent-and-secure-rbac.html
 
 ## Conformance Tests
 

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -141,9 +141,14 @@ A role named "`domain-manager`" is to be created via the Keystone API and the po
 
 # allow domain managers to manage role assignments within their domain
 # (restricted to specific roles by the 'is_domain_managed_role' rule)
+#
+# project-level role assignment to user within domain
 "is_domain_user_project_grant": "token.domain.id:%(target.user.domain_id)s and token.domain.id:%(target.project.domain_id)s and rule:is_domain_managed_role"
+# project-level role assignment to group within domain
 "is_domain_group_project_grant": "token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.project.domain_id)s and rule:is_domain_managed_role"
-"domain_manager_grant": "rule:is_domain_manager and (rule:is_domain_user_project_grant or rule:is_domain_group_project_grant)"
+# domain-level role assignment to group
+"is_domain_level_group_grant": "token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.domain.id)s and rule:is_domain_managed_role"
+"domain_manager_grant": "rule:is_domain_manager and (rule:is_domain_user_project_grant or rule:is_domain_group_project_grant or rule:is_domain_level_group_grant)"
 "identity:check_grant": "rule:domain_manager_grant or rule:admin_required"
 "identity:list_grants": "rule:domain_manager_grant or rule:admin_required"
 "identity:create_grant": "rule:domain_manager_grant or rule:admin_required"

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -104,7 +104,7 @@ A role named "`domain-manager`" is to be created via the Keystone API and the po
 
 # specify a rule that whitelists roles which domain admins are permitted
 # to assign and revoke within their domain
-"is_domain_managed_role": "%(target.role.name)s:member"
+"is_domain_managed_role": "'member':%(target.role.name)s"
 
 # allow domain admins to retrieve their own domain
 "identity:get_domain": "(rule:is_domain_manager and token.domain.id:%(target.domain.id)s) or rule:admin_required"

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -57,7 +57,11 @@ To address this, this standard defines a new Domain Manager role in conjunction 
 - the Domain Manager role MUST support managing projects, groups and users within a specific domain
 - the Domain Manager role MUST be properly scoped to a domain, it MUST NOT gain access to resources outside of its owning domain
 - the Domain Manager role MUST NOT be able to manipulate existing roles or create new roles
-- the Domain Manager role MUST only be allowed to assign specific non-administrative roles to their managed users, Domain Managers MUST NOT be able to abuse the role assignment functionalities to escalate their own privileges or those of other users
+- the Domain Manager role MUST only be able to assign specific non-administrative\* roles to their managed users where the applicable roles are defined by the CSP
+- Domain Managers MUST NOT be able to abuse the role assignment functionalities to escalate their own privileges or those of other users beyond the roles defined by the CSP
+
+\* "non-administrative" in this context means this excludes the role "`admin`" and any comparable role that grants permissions beyond domain and tenant scope.
+Since the Domain Manager role as defined in this standard is domain-scoped, it does not count as administrative.
 
 ### Options considered
 

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -77,7 +77,7 @@ This results in special permissions being granted to users possessing the role w
 This poses severe security risks as the proper scoping of the `admin` role is impossible.
 **Due to this, this approach was discarded early.**
 
-Upstream is in the process of addressing this across the services but it has not been fully implemented yet, especially for domains[^3].
+Upstream (OpenStack) is in the process of addressing this across the services but it has not been fully implemented yet, especially for domains[^3].
 
 [^2]: [Launchpad bug: "admin"-ness not properly scoped](https://bugs.launchpad.net/keystone/+bug/968696)
 
@@ -195,7 +195,7 @@ The "`is_domain_managed_role`" rule of the above policy template may be adjusted
 - the "`is_domain_managed_role`" rule MUST NOT contain the "`admin`" role, neither directly nor transitively
 - the "`is_domain_managed_role`" rule MUST define all applicable roles directly, it MUST NOT contain a "`rule:`" reference within itself
 
-**Example: permitting multiple roles**
+##### Example: permitting multiple roles
 
 The following example permits both the "`member`" and "`reader`" role to be assigned/revoked by a Domain Manager.
 Further roles can be appended using the logical `or` directive.
@@ -229,10 +229,10 @@ Aims to introduce support for a scoped `manager` role by 2024 but only focuses o
 
 ## Conformance Tests
 
-There is a test suite in [`domain-manager-check.py`](../Tests/iam/domain-manager/domain-manager-check.py).
+There is a test suite in [`domain-manager-check.py`](https://github.com/SovereignCloudStack/standards/blob/main/Tests/iam/domain-manager/domain-manager-check.py).
 The test suite connects to the OpenStack API using two sample domains and corresponding Domain Manager accounts.
 It verifies the compliance to the standard and the proper domain-scoping as defined by the Keystone policy.
-Please consult the associated [README.md](../Tests/iam/domain-manager/README.md) for detailed setup and testing instructions.
+Please consult the associated [README.md](https://github.com/SovereignCloudStack/standards/blob/main/Tests/iam/domain-manager/README.md) for detailed setup and testing instructions.
 
 ## Appendix
 
@@ -292,7 +292,7 @@ Decision:
 
 Rationale:
 
-- avoid confusion with the unscoped admin role and to be inline with the upstream plan: https://specs.openstack.org/openstack/keystone-specs/specs/keystone/2023.1/default-service-role.html
+- avoid confusion with the unscoped admin role and to be inline with the upstream plan: [Default Service Role - Identity Specs](https://specs.openstack.org/openstack/keystone-specs/specs/keystone/2023.1/default-service-role.html)
 
 Links / Comments / References:
 

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -148,7 +148,9 @@ A role named "`domain-manager`" is to be created via the Keystone API and the po
 "is_domain_group_project_grant": "token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.project.domain_id)s and rule:is_domain_managed_role"
 # domain-level role assignment to group
 "is_domain_level_group_grant": "token.domain.id:%(target.group.domain_id)s and token.domain.id:%(target.domain.id)s and rule:is_domain_managed_role"
-"domain_manager_grant": "rule:is_domain_manager and (rule:is_domain_user_project_grant or rule:is_domain_group_project_grant or rule:is_domain_level_group_grant)"
+# domain-level role assignment to user
+"is_domain_level_user_grant": "token.domain.id:%(target.user.domain_id)s and token.domain.id:%(target.domain.id)s and rule:is_domain_managed_role"
+"domain_manager_grant": "rule:is_domain_manager and (rule:is_domain_user_project_grant or rule:is_domain_group_project_grant or rule:is_domain_level_group_grant or rule:is_domain_level_user_grant)"
 "identity:check_grant": "rule:domain_manager_grant or rule:admin_required"
 "identity:list_grants": "rule:domain_manager_grant or rule:admin_required"
 "identity:create_grant": "rule:domain_manager_grant or rule:admin_required"

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -193,3 +193,37 @@ There is a test suite in [`domain-manager-check.py`](../Tests/iam/domain-manager
 The test suite connects to the OpenStack API using two sample domains and corresponding Domain Manager accounts.
 It verifies the compliance to the standard and the proper domain-scoping as defined by the Keystone policy.
 Please consult the associated [README.md](../Tests/iam/domain-manager/README.md) for detailed setup and testing instructions.
+
+## Appendix
+
+### Decision Record
+
+#### Extend domain management functionality to Keystone groups
+
+Decision Date: 2023-08-04
+
+Decision Maker: SIG IAM
+
+Decision: The Domain Manager Standard configuration should cover the groups functionality of Keystone, allowing domain manager to manage groups in domains.
+
+Rationale: The groups functionality is a desired IAM feature for customers.
+
+Links / Comments / References:
+
+- [SIG IAM meeting protocol entry](https://input.scs.community/2023-scs-sig-iam#Domain-Admin-rights-for-SCS-IaaS-Customers-184)
+- [action item issue](https://github.com/SovereignCloudStack/issues/issues/383)
+
+#### Change the naming of the Domain Manager role
+
+Decision Date: 2023-08-04
+
+Decision Maker: SIG IAM
+
+Decision: Role should be named "domain-manager" not "domain-admin".
+
+Rationale: To avoid confusion with the unscoped admin role and to be inline with the upstream plan https://specs.openstack.org/openstack/keystone-specs/specs/keystone/2023.1/default-service-role.html
+
+Links / Comments / References:
+
+- [SIG IAM meeting protocol entry](https://input.scs.community/2023-scs-sig-iam#Domain-Admin-rights-for-SCS-IaaS-Customers-184)
+- [issue commment about decision](https://github.com/SovereignCloudStack/issues/issues/184#issuecomment-1670985934)

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -189,4 +189,7 @@ Aims to introduce support for a scoped `manager` role by 2024 but only focuses o
 
 ## Conformance Tests
 
-Conformance Tests, OPTIONAL
+There is a test suite in [`domain-manager-check.py`](../Tests/iam/domain-manager/domain-manager-check.py).
+The test suite connects to the OpenStack API using two sample domains and corresponding Domain Manager accounts.
+It verifies the compliance to the standard and the proper domain-scoping as defined by the Keystone policy.
+Please consult the associated [README.md](../Tests/iam/domain-manager/README.md) for detailed setup and testing instructions.

--- a/Standards/scs-0302-v1-domain-manager-role.md
+++ b/Standards/scs-0302-v1-domain-manager-role.md
@@ -138,6 +138,7 @@ A role named "`domain-manager`" is to be created via the Keystone API and the po
 "identity:create_project": "(rule:is_domain_manager and token.domain.id:%(target.project.domain_id)s) or rule:admin_required"
 "identity:update_project": "(rule:is_domain_manager and token.domain.id:%(target.project.domain_id)s) or rule:admin_required"
 "identity:delete_project": "(rule:is_domain_manager and token.domain.id:%(target.project.domain_id)s) or rule:admin_required"
+"identity:list_user_projects": "(rule:is_domain_manager and token.domain.id:%(target.user.domain_id)s) or rule:admin_required"
 
 # allow domain managers to manage role assignments within their domain
 # (restricted to specific roles by the 'is_domain_managed_role' rule)

--- a/Tests/iam/domain-manager/README.md
+++ b/Tests/iam/domain-manager/README.md
@@ -18,6 +18,12 @@ The creation of these resources is described below.
 
 **WARNING:** Replace the `<REPLACEME>` password placeholders by securely generated passwords in the code blocks below.
 
+As a preliminary step, create the "`domain-manager`" role if it does not exist:
+
+```bash
+openstack role create domain-manager
+```
+
 First, create two testing domains and a domain manager for each domain:
 
 ```bash

--- a/Tests/iam/domain-manager/README.md
+++ b/Tests/iam/domain-manager/README.md
@@ -14,9 +14,9 @@ The following things are required:
 
 The creation of these resources is described below.
 
-> **NOTE:** The following steps require cloud admin rights.
+**NOTE:** The following steps require cloud admin rights.
 
-> **WARNING:** Replace the `<REPLACEME>` password placeholders by securely generated passwords in the code blocks below.
+**WARNING:** Replace the `<REPLACEME>` password placeholders by securely generated passwords in the code blocks below.
 
 First, create two testing domains and a domain manager for each domain:
 
@@ -61,7 +61,6 @@ The content of the file is structured as follows:
 | `domains.*.manager` | Login credentials for a user with the `domain-manager` role within the respective domain |
 | `domains.*.member_role` | Role that a domain manager is permitted to assign users within the respective domain (default: `member`) |
 
-
 ### Test Execution Environment
 
 > **NOTE:** The test execution procedure does not require cloud admin rights.
@@ -87,12 +86,11 @@ Within this environment execute the test suite.
 
 [^2]: [Python 3 Documentation: Virtual Environments and Packages](https://docs.python.org/3/tutorial/venv.html)
 
-
 ## Test Execution
 
 The test suite is executed as follows:
 
-```
+```bash
 python3 domain-manager-check.py --os-cloud mycloud
 ```
 
@@ -112,12 +110,11 @@ clouds:
 
 If the test suite fails and leaves test resources behind, the "`--cleanup-only`" flag may be used to delete those resources from the domains:
 
-```
+```bash
 python3 domain-manager-check.py --os-cloud mycloud --cleanup-only
 ```
 
 For any further options consult the output of "`python3 domain-manager-check.py --help`".
-
 
 ### Script Behavior & Test Results
 

--- a/Tests/iam/domain-manager/README.md
+++ b/Tests/iam/domain-manager/README.md
@@ -1,0 +1,134 @@
+# Domain Manager Standard Test Suite
+
+## Test Environment Setup
+
+### OpenStack Domains and Accounts
+
+The test suite requires a specific domain setup to exist in the OpenStack cloud.
+This setup must be prepared before starting test execution.
+The following things are required:
+
+- two domains for testing
+- a user in each domain with the `domain-manager` role assigned on domain-level
+- a properly configured "`domain-manager-test.yaml`"
+
+The creation of these resources is described below.
+
+> **NOTE:** The following steps require cloud admin rights.
+
+> **WARNING:** Replace the `<REPLACEME>` password placeholders by securely generated passwords in the code blocks below.
+
+First, create two testing domains and a domain manager for each domain:
+
+```bash
+openstack domain create scs-test-domain-a
+openstack domain create scs-test-domain-b
+
+openstack user create --domain scs-test-domain-b \
+    --password "<REPLACEME>" scs-test-domain-b-manager
+openstack user create --domain scs-test-domain-a \
+    --password "<REPLACEME>" scs-test-domain-a-manager
+
+openstack role add --user scs-test-domain-a-manager \
+    --domain scs-test-domain-a domain-manager
+openstack role add --user scs-test-domain-b-manager \
+    --domain scs-test-domain-b domain-manager
+```
+
+Next create a file "`domain-manager-test.yaml`" with the following content:
+
+```yaml
+domains:
+  - name: "scs-test-domain-a"
+    manager:
+      username: "scs-test-domain-a-manager"
+      password: "<REPLACEME>"
+    member_role: "member"
+  - name: "scs-test-domain-b"
+    manager:
+      username: "scs-test-domain-b-manager"
+      password: "<REPLACEME>"
+    member_role: "member"
+```
+
+The YAML file should contain two domains.
+A sample file is included in this repository.
+The content of the file is structured as follows:
+
+| Setting | Purpose |
+|---|---|
+| `domains.*.name` | Name of the domain |
+| `domains.*.manager` | Login credentials for a user with the `domain-manager` role within the respective domain |
+| `domains.*.member_role` | Role that a domain manager is permitted to assign users within the respective domain (default: `member`) |
+
+
+### Test Execution Environment
+
+> **NOTE:** The test execution procedure does not require cloud admin rights.
+
+To execute the test suite, the "`domain-manager-test.yaml`" configuration file as created above is required as input.
+Furthermore, a valid cloud configuration for the OpenStack SDK in the shape of "`clouds.yaml`" is mandatory[^1].
+**Both files are expected to be located in the current working directory where the test script is executed unless configured otherwise.**
+
+[^1]: [OpenStack Documentation: Configuring OpenStack SDK Applications](https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html)
+
+The test execution environment can be located on any system outside of the cloud infrastructure that has OpenStack API access.
+Make sure that the API access is configured properly in "`clouds.yaml`".
+The test suite will start with some basic login tests to verify the API connection for both domains and domain manager accounts.
+
+It is recommended to use a Python virtual environment[^2].
+Next, install the OpenStack SDK required by the test suite:
+
+```bash
+pip3 install openstacksdk
+```
+
+Within this environment execute the test suite.
+
+[^2]: [Python 3 Documentation: Virtual Environments and Packages](https://docs.python.org/3/tutorial/venv.html)
+
+
+## Test Execution
+
+The test suite is executed as follows:
+
+```
+python3 domain-manager-check.py --os-cloud mycloud
+```
+
+As an alternative to "`--os-cloud`", the "`OS_CLOUD`" environment variable may be specified instead.
+The parameter is used to look up the correct cloud configuration in "`clouds.yaml`".
+For the example command above, this file should contain a `clouds.mycloud` section like this:
+
+```yaml
+---
+clouds:
+  mycloud:
+    auth:
+      auth_url: ...
+      ...
+    ...
+```
+
+If the test suite fails and leaves test resources behind, the "`--cleanup-only`" flag may be used to delete those resources from the domains:
+
+```
+python3 domain-manager-check.py --os-cloud mycloud --cleanup-only
+```
+
+For any further options consult the output of "`python3 domain-manager-check.py --help`".
+
+
+### Script Behavior & Test Results
+
+> **NOTE:** Before any execution of test batches, the script will automatically perform a cleanup of the configured domains, deleting all users, projects and groups matching a special prefix (see the "`--prefix`" flag).
+> This cleanup behavior is identical to "`--cleanup-only`".
+
+The script will print all cleanup actions and passed tests to `stdout`.
+
+If all tests pass, the script will return with an exit code of `0`.
+
+If any test fails, the script will halt, print the exact error to `stderr` and return with a non-zero exit code.
+
+In case of a failed test, cleanup is not performed automatically, allowing for manual inspection of the cloud state for debugging purposes.
+Although unnecessary due to automatic cleanup upon next execution, you can manually trigger a cleanup using the "`--cleanup-only`" flag of this script.

--- a/Tests/iam/domain-manager/domain-manager-check.py
+++ b/Tests/iam/domain-manager/domain-manager-check.py
@@ -1,0 +1,1267 @@
+"""Domain Manager policy configuration checker
+
+This script uses the OpenStack SDK to validate the proper implementation
+of the Domain Manager standard via the OpenStack Keystone API.
+It verifies that domain managers are able to manage users, projects and groups
+within their respective domain while being unable to manage such resources in
+domains other than their own.
+
+This script requires a domain-manager-test.yaml that defines the domains
+and domain manager login credentials to be used for test execution.
+Furthermore, a properly configured clouds.yaml for the OpenStack SDK is
+required.
+
+You may run this script with the "--cleanup-only" flag to remove any leftovers
+from previous executions of this test suite.
+This will remove all IAM resources (projects, users, groups - except for the
+domain managers themselves) within the configured test domains that have the
+TEST_RESOURCES_PREFIX in front of their name. The script expects the configured
+test domains to be empty!
+"""
+
+import openstack
+import os
+import yaml
+import argparse
+import keystoneauth1
+
+# prefix to be included in the names of any Keystone resources created
+# used by the cleanup routine to identify resources that can be safely deleted
+DEFAULT_PREFIX = "scs-test-"
+
+
+def connect(cloud_name: str,
+            auth_overrides: dict = None) -> openstack.connection.Connection:
+    """Create a connection to an OpenStack cloud
+
+    :param string cloud_name:
+        The name of the configuration to load from clouds.yaml.
+    :param dict auth_overrides:
+        A dict that overrides option of the auth section of the cloud
+        configuration of the loaded clouds.yaml. Allows to authenticate
+        as a different user based on the same general cloud settings.
+        Example:
+
+            {
+                "username": "claudia",
+                "password": "foobar123!%",
+                "project_name": "customer1"
+            }
+
+    :returns: openstack.connnection.Connection
+    """
+
+    if auth_overrides:
+        return openstack.connect(
+            cloud=cloud_name,
+            auth=auth_overrides
+        )
+    else:
+        return openstack.connect(
+            cloud=cloud_name,
+        )
+
+
+def connect_to_domain(cloud_name: str,
+                      domain: str,
+                      domain_definitions: list[dict]
+                      ) -> openstack.connection.Connection:
+    domain_def = next(d for d in domain_definitions if d.get("name") == domain)
+    auth = {
+        "username": domain_def.get("manager").get("username"),
+        "password": domain_def.get("manager").get("password"),
+        "project_name": "",
+        "project_domain_name": "",
+        "domain_name": domain_def.get("name"),
+        "user_domain_name": domain_def.get("name"),
+    }
+    return connect(cloud_name, auth_overrides=auth)
+
+
+def load_domain_definitions(yaml_path: str) -> list[dict]:
+    assert os.path.exists(yaml_path), (
+        f"Test definition YAML '{yaml_path}' does not exist"
+    )
+    # validate the schema of the file after loading it
+    with open(yaml_path, 'r') as f:
+        definitions = yaml.safe_load(f)
+        assert "domains" in definitions, (
+            f"Test definition YAML '{yaml_path}' "
+            f"is missing a 'domains' section")
+
+        assert len(definitions.get("domains")) > 1, (
+            f"Test definition YAML '{yaml_path}' "
+            f"has less than 2 entries in the 'domains' section; "
+            f"at least 2 are required")
+
+        for domain in definitions.get("domains"):
+            assert "name" in domain, (
+                f"At least one domain in the test definition YAML "
+                f"'{yaml_path}' is missing the 'name' property")
+            domain_name = domain.get("name")
+            assert "manager" in domain, (
+                f"Domain '{domain_name}' in the test definition YAML "
+                f"'{yaml_path}' is missing the 'manager' subsection")
+            manager = domain.get("manager")
+            assert "username" in manager, (
+                f"Domain '{domain_name}' in the test definition YAML "
+                f"'{yaml_path}' is missing the 'manager.username' property")
+            assert "password" in manager, (
+                f"Domain '{domain_name}' in the test definition YAML "
+                f"'{yaml_path}' is missing the 'manager.password' property")
+        return definitions
+
+
+def test_logins(cloud_name: str, domains: list[dict]):
+    print("\nExecuting tests for basic logins ...")
+    for domain in domains:
+        domain_name = domain.get("name")
+        domain_manager = domain["manager"]["username"]
+        conn = connect_to_domain(cloud_name, domain_name, domains)
+        try:
+            conn.identity.find_user(domain_manager)
+        except keystoneauth1.exceptions.http.Unauthorized:
+            raise Exception(
+                f"Login as '{domain_manager}' in domain '{domain_name}' "
+                f"failed; make sure that user and domain membership are "
+                f"properly configured"
+            )
+        try:
+            assert conn.identity.find_domain(domain_name), (
+                f"Lookup of domain '{domain_name}' returned None"
+            )
+        except Exception as e:
+            print(str(e))
+            raise Exception(
+                f"User '{domain_manager}' cannot discover their own domain "
+                f"'{domain_name}'; make sure that Keystone policies are "
+                f"correctly applied"
+            )
+        print(f"Domain manager login for domain '{domain_name}' works: PASS")
+
+
+def cleanup(cloud_name: str, domains: list[dict], prefix=DEFAULT_PREFIX):
+    """
+    Uses the configured domain manager users to cleanup any Keystone resources
+    that this test suite might have created in the corresponding domains
+    during any previous or current execution.
+    Resources are discovered within the domains configured for testing only
+    and are also checked against a specific name prefix that all test resources
+    have to avoid accidental deletion of non-test resources.
+    """
+    print(f"\nPerforming cleanup for resources with the "
+          f"'{prefix}' prefix ...")
+    for domain in domains:
+        domain_name = domain.get("name")
+        print(f"Cleanup starting for domain {domain_name} ...")
+        conn = connect_to_domain(cloud_name, domain_name, domains)
+        domain_id = conn.identity.find_domain(domain_name).id
+
+        groups = conn.identity.groups(domain_id=domain_id)
+        for group in groups:
+            if group.name.startswith(prefix):
+                print(f"↳ deleting group '{group.name}' ...")
+                conn.identity.delete_group(group.id)
+
+        projects = conn.identity.projects(domain_id=domain_id)
+        for project in projects:
+            if project.name.startswith(prefix):
+                print(f"↳ deleting project '{project.name}' ...")
+                conn.identity.delete_project(project.id)
+
+        users = conn.identity.users(domain_id=domain_id)
+        for user in users:
+            if user.name == domain["manager"]["username"]:
+                # manager should not delete themselves
+                print(f"↳ skipping user '{user.name}' (is domain manager) ...")
+                continue
+            if user.name.startswith(prefix):
+                print(f"↳ deleting user '{user.name}' ...")
+                conn.identity.delete_user(user.id)
+
+
+def _raisesException(exception, func, *args, **kwargs):
+    """
+    Mimics the functionality of `assertRaises()` for plain `assert`.
+    Calls the function passed as `func` and observes the exception behavior.
+    If it raises the exception passed as `exception`, returns True.
+    If it raises any other exception, the exception is re-raised.
+    In any other case returns False.
+
+    To be used in `assert` statements.
+    """
+    try:
+        func(*args, **kwargs)
+    except exception:
+        return True
+    except Exception as e:
+        raise e
+    else:
+        return False
+
+
+def test_users(cloud_name: str, domains: list[dict], prefix=DEFAULT_PREFIX):
+    """
+    Test correct domain scoping for domain managers relating to the users
+    feature of Keystone.
+    """
+    print("\nExecuting tests for Keystone users ...")
+
+    # 1st domain = D1
+    domain_a_name = domains[0].get("name")
+    conn_a = connect_to_domain(cloud_name, domain_a_name, domains)
+    domain_a = conn_a.identity.find_domain(domain_a_name)
+    domain_a_role = conn_a.identity.find_role(domains[0].get("member_role"))
+
+    # 2nd domain = D2
+    domain_b_name = domains[1].get("name")
+    conn_b = connect_to_domain(cloud_name, domain_b_name, domains)
+    domain_b = conn_b.identity.find_domain(domain_b_name)
+    domain_b_role = conn_b.identity.find_role(domains[1].get("member_role"))
+
+    domain_a_user_name = f"{prefix}domain-a-user"
+    domain_b_user_name = f"{prefix}domain-b-user"
+
+    # [D1] domain manager can create user within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_user,
+        name=domain_a_user_name,
+        domain_id=domain_a.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"create user within domain"
+    )
+    print("Domain manager can create user within domain: PASS")
+
+    # [D1] domain manager can find user by id or name within domain
+    domain_a_user = conn_a.identity.find_user(domain_a_user_name)
+    assert domain_a_user is not None, (
+        f"Policy error: domain manager of '{domain_a.name}' cannot find user "
+        f"'{domain_a_user_name}' by name within domain"
+    )
+    assert conn_a.identity.find_user(domain_a_user.id) is not None, (
+        f"Policy error: domain manager of '{domain_a.name}' cannot find user "
+        f"'{domain_a_user_name}' by id within domain"
+    )
+    print("Domain manager can find user within domain: PASS")
+
+    # D1 domain manager can update user within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.update_user,
+        domain_a_user.id, email="CHANGED-MAIL"
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"update user '{domain_a_user.name}' within domain"
+    )
+    # refresh the user object
+    domain_a_user = conn_a.identity.find_user(domain_a_user_name)
+    assert domain_a_user is not None and \
+        domain_a_user.email == "CHANGED-MAIL", (
+            f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+            f"successfully update user '{domain_a_user.name}'s email address "
+            f"within domain"
+        )
+    print("Domain manager can update user metadata within domain: PASS")
+
+    # prepare a user in D2 for all subsequent tests
+    domain_b_user = conn_b.identity.create_user(
+        name=domain_b_user_name, domain_id=domain_b.id
+    )
+
+    # [D1] domain manager can only find users within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.users
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"list users"
+    )
+    # the user of D2 should not appear in the list
+    for found_user in list(conn_a.identity.users()):
+        assert found_user.domain_id == domain_a.id, (
+            f"Policy error: domain manager of domain '{domain_a.name}' is "
+            f"able to list users outside of domain"
+        )
+    print("Domain manager can only list users within domain: PASS")
+
+    # [D1] domain manager can assign domain-level role to user within domain
+    # note that assign_domain_role_to_user() and
+    # unassign_domain_role_from_user() do not raise any exception if they fail
+    # the result must be checked by querying resulting assignments
+    conn_a.identity.assign_domain_role_to_user(
+        domain_a.id, domain_a_user.id, domain_a_role.id
+    )
+    assert conn_a.identity.validate_user_has_domain_role(
+        domain_a.id, domain_a_user.id, domain_a_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"assign domain-level role to user '{domain_a_user.name}' within "
+        f"domain"
+    )
+    print("Domain manager can assign domain-level role to user within domain: "
+          "PASS")
+    conn_a.identity.unassign_domain_role_from_user(
+        domain_a.id, domain_a_user.id, domain_a_role.id
+    )
+    assert not conn_a.identity.validate_user_has_domain_role(
+        domain_a.id, domain_a_user.id, domain_a_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"unassign domain-level role to user '{domain_a_user.name}' within "
+        f"domain"
+    )
+    print("Domain manager can unassign domain-level role from user within "
+          "domain: PASS")
+
+    # [D1] domain manager can delete user within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.delete_user,
+        domain_a_user.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"delete user '{domain_a_user.name}' within domain"
+    )
+    print("Domain manager can delete user within domain: PASS")
+
+    # [D1] domain manager cannot create user without domain scope (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_user,
+        name=f"{domain_a_user_name}-outside-of-a"
+    ), (
+        f"Policy error: domain manager of dofmain '{domain_a.name}' is able to "
+        f"create user outside of domain scope"
+    )
+    print("Domain manager cannot create user outside of domain scope: PASS")
+
+    # [D1] domain manager cannot create user in D2 (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_user,
+        name=f"{domain_a_user_name}-in-domain-2",
+        domain_id=domain_b.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"create user in foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot create user in foreign domain: PASS")
+
+    # [D1] cannot find user in D2 (negative test)
+    user = conn_a.identity.find_user(domain_b_user.id)
+    assert user is None, (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"find user '{domain_b_user.name}' of foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot find user in foreign domain: PASS")
+
+    # [D1] domain manager cannot update user in D2 (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.update_user,
+        domain_b_user.id,
+        email="CHANGED-MAIL"
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"update user '{domain_b_user.name}' of foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot update user in foreign domain: PASS")
+
+    # [D1] domain manager cannot delete user in D2 (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.delete_user,
+        domain_b_user.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"delete user '{domain_b_user.name}' of foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot delete user in foreign domain: PASS")
+
+    # [D1] domain manager cannot assign domain-level role to user in D2
+    # there are two cases: assigning a role within domain D2 to:
+    # 1) user is part of domain D1
+    conn_a.identity.assign_domain_role_to_user(
+        domain_b.id, domain_a_user.id, domain_b_role.id
+    )
+    assert not conn_a.identity.validate_user_has_domain_role(
+        domain_b.id, domain_a_user.id, domain_b_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"assign domain-level role to user '{domain_a_user.name}' within "
+        f"foreign domain '{domain_b.name}'"
+    )
+    # 2) user is part of domain D2
+    conn_a.identity.assign_domain_role_to_user(
+        domain_b.id, domain_b_user.id, domain_b_role.id
+    )
+    assert not conn_b.identity.validate_user_has_domain_role(
+        domain_b.id, domain_b_user.id, domain_b_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"assign domain-level role to user '{domain_b_user.name}' within "
+        f"foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot assign domain-level role to user in foreign "
+          "domain: PASS")
+
+    # [D1] domain manager cannot unassign domain-level role from user in D2
+    # first prepare the assignment as domain manager of D2 via conn_b
+    conn_b.identity.assign_domain_role_to_user(
+        domain_b.id, domain_b_user.id, domain_b_role.id
+    )
+    assert conn_b.identity.validate_user_has_domain_role(
+        domain_b.id, domain_b_user.id, domain_b_role.id
+    ), (
+        f"Test setup error: assigning domain-level to user "
+        f"'{domain_b_user.name}' within domain '{domain_b.name}' "
+        f"as domain manager of domain '{domain_b.name}' failed but is "
+        f"required by the testing process; please check "
+        f"the test implementation and domain configuration"
+    )
+    # next, attempt to unassign as domain manager of D1 via conn_a
+    conn_a.identity.unassign_domain_role_from_user(
+        domain_b.id, domain_b_user.id, domain_b_role.id
+    )
+    assert conn_b.identity.validate_user_has_domain_role(
+        domain_b.id, domain_b_user.id, domain_b_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"unassign domain-level role from user '{domain_b_user.name}' within "
+        f"foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot unassign domain-level role from user in "
+          "foreign domain: PASS")
+
+
+def test_projects(cloud_name: str, domains: list[dict], prefix=DEFAULT_PREFIX):
+    """
+    Test correct domain scoping for domain managers relating to the projects
+    feature of Keystone.
+    """
+    print("\nExecuting tests for Keystone projects ...")
+
+    # 1st domain = D1
+    domain_a_name = domains[0].get("name")
+    conn_a = connect_to_domain(cloud_name, domain_a_name, domains)
+    domain_a = conn_a.identity.find_domain(domain_a_name)
+    domain_a_role = conn_a.identity.find_role(domains[0].get("member_role"))
+    domain_a_user = conn_a.identity.create_user(
+        name=f"{prefix}domain-a-user", domain_id=domain_a.id
+    )
+
+    # 2nd domain = D2
+    domain_b_name = domains[1].get("name")
+    conn_b = connect_to_domain(cloud_name, domain_b_name, domains)
+    domain_b = conn_b.identity.find_domain(domain_b_name)
+    domain_b_role = conn_b.identity.find_role(domains[1].get("member_role"))
+    domain_b_user = conn_b.identity.create_user(
+        name=f"{prefix}domain-b-user", domain_id=domain_b.id
+    )
+
+    domain_a_project_name = f"{prefix}domain-a-project"
+    domain_b_project_name = f"{prefix}domain-b-project"
+
+    # [D1] domain manager can project user within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_project,
+        name=domain_a_project_name,
+        domain_id=domain_a.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"create project within domain"
+    )
+    print("Domain manager can create project within domain: PASS")
+
+    # [D1] domain manager can find project by id or name within domain
+    domain_a_project = conn_a.identity.find_project(domain_a_project_name)
+    assert domain_a_project is not None, (
+        f"Policy error: domain manager of '{domain_a.name}' cannot find "
+        f"project '{domain_a_project_name}' by name within domain"
+    )
+    assert conn_a.identity.find_project(domain_a_project.id) is not None, (
+        f"Policy error: domain manager of '{domain_a.name}' cannot find "
+        f"project '{domain_a_project_name}' by id within domain"
+    )
+    print("Domain manager can find project within domain: PASS")
+
+    # D1 domain manager can update project within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.update_project,
+        domain_a_project.id, description="CHANGED-DESCRIPTION"
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"update project '{domain_a_project.name}' within domain"
+    )
+    # refresh the project object
+    domain_a_project = conn_a.identity.find_project(domain_a_project_name)
+    assert domain_a_project is not None and \
+        domain_a_project.description == "CHANGED-DESCRIPTION", (
+            f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+            f"successfully update project '{domain_a_project.name}'s "
+            f"description within domain"
+        )
+    print("Domain manager can update project metadata within domain: PASS")
+
+    # [D1] domain manager can assign project-level role to user within domain
+    # note that assign_domain_role_to_user() does not raise exceptions; results
+    # have to be checked explicitly
+    conn_a.identity.assign_project_role_to_user(
+        domain_a_project.id, domain_a_user.id, domain_a_role.id
+    )
+    assert conn_a.identity.validate_user_has_project_role(
+        domain_a_project.id, domain_a_user.id, domain_a_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"assign project-level role to user '{domain_a_user.name}' for "
+        f"project '{domain_a_project.name}' within domain"
+    )
+    print("Domain manager can assign project-level role to user within domain: "
+          "PASS")
+
+    # [D1] domain manager can list projects for user in domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.user_projects,
+        domain_a_user.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"list projects for user '{domain_a_user.name}' within domain"
+    )
+    projects = list(conn_a.identity.user_projects(domain_a_user.id))
+    assert len(projects) == 1 and projects[0].id == domain_a_project.id, (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"successfully list projects for user '{domain_a_user.name}' within "
+        f"domain"
+    )
+    print("Domain manager can list projects for user within domain: PASS")
+
+    # [D1] domain manager can unassign project-level role from user within
+    # domain
+    # note that unassign_project_role_from_user() does not raise exceptions;
+    # results have to be checked explicitly
+    conn_a.identity.unassign_project_role_from_user(
+        domain_a_project.id, domain_a_user.id, domain_a_role.id
+    )
+    assert not conn_a.identity.validate_user_has_project_role(
+        domain_a_project.id, domain_a_user.id, domain_a_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"successfully unassign project-level role from user "
+        f"'{domain_a_user.name}' for project '{domain_a_project.name}' within "
+        f"domain"
+    )
+    print("Domain manager can unassign project-level role from user within "
+          "domain: PASS")
+
+    # [D1] domain manager can list projects for user in domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.delete_project,
+        domain_a_project.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot "
+        f"delete project '{domain_a_project.name}' within domain"
+    )
+    print("Domain manager can delete project within domain: PASS")
+
+    # [D1] domain manager cannot create project without domain scope (negative
+    # test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_project,
+        name=f"{domain_a_project_name}-outside-of-a",
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"create project without domain scope"
+    )
+    print("Domain manager cannot create project outside of domain scope: PASS")
+
+    # [D1] domain manager cannot create project in domain D2 (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_project,
+        name=f"{domain_a_project_name}-in-b",
+        domain_id=domain_b.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"create project in foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot create project in foreign domain: PASS")
+
+    # create a project in D2 for further tests
+    domain_b_project = conn_b.identity.create_project(
+        name=domain_b_project_name,
+        domain_id=domain_b.id
+    )
+
+    # [D1] domain manager cannot discover project in foreign domain D2
+    # (negative test)
+    assert conn_a.identity.find_project(domain_b_project_name) is None, (
+        f"Policy error: domain manager of '{domain_a.name}' is able to find "
+        f"project '{domain_b_project_name}' by name in foreign domain "
+        f"'{domain_b.name}'"
+    )
+    assert conn_a.identity.find_project(domain_b_project.id) is None, (
+        f"Policy error: domain manager of '{domain_a.name}' is able to find "
+        f"project '{domain_b_project_name}' by id in foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot find project in foreign domain: PASS")
+
+    # [D1] domain manager cannot update project in foreign domain D2 (negative
+    # test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.update_project,
+        domain_b_project.id,
+        description="CHANGED-DESCRIPTION"
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"update project '{domain_b_project.name}' of foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot update project in foreign domain: PASS")
+
+    # [D1] domain manager cannot delete project in foreign domain D2 (negative
+    # test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.delete_project,
+        domain_b_project.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"delete project '{domain_b_project.name}' of foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot delete project in foreign domain: PASS")
+
+    # [D1] domain manager cannot assign project-level role to user within
+    # foreign domain D2 (negative test)
+    # 1) user in D2 + project in D2
+    conn_a.identity.assign_project_role_to_user(
+        domain_b_project.id, domain_b_user.id, domain_b_role.id
+    )
+    # as conn_b check the assignment
+    assert not conn_b.identity.validate_user_has_project_role(
+        domain_b_project.id, domain_b_user.id, domain_b_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"assign project-level role to user '{domain_b_user.name}' "
+        f"for project '{domain_b_project.name}' within foreign domain "
+        f"'{domain_b.name}'"
+    )
+    # 2) user in D2 + project in D1
+    conn_a.identity.assign_project_role_to_user(
+        domain_a_project.id, domain_b_user.id, domain_a_role.id
+    )
+    # as conn_b check the assignment
+    assert not conn_b.identity.validate_user_has_project_role(
+        domain_a_project.id, domain_b_user.id, domain_a_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"assign project-level role to user '{domain_b_user.name}' of foreign domain "
+        f"'{domain_b.name}' "
+        f"for project '{domain_a_project.name}'"
+    )
+    # 3) user in D1 + project in D2
+    conn_a.identity.assign_project_role_to_user(
+        domain_b_project.id, domain_a_user.id, domain_b_role.id
+    )
+    # as conn_b check the assignment
+    assert not conn_b.identity.validate_user_has_project_role(
+        domain_b_project.id, domain_a_user.id, domain_b_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"assign project-level role to user '{domain_a_user.name}' for "
+        f"project '{domain_b_project.name}' of foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot assign project-level role to user within "
+          "foreign domain: PASS")
+
+    # [D1] domain manager cannot unassign project-level role from user in
+    # foreign domain (negative test)
+    #
+    # first, prepare a valid role assignment in the forein project using conn_b
+    conn_b.identity.assign_project_role_to_user(
+        domain_b_project.id, domain_b_user.id, domain_b_role.id
+    )
+    assert conn_b.identity.validate_user_has_project_role(
+        domain_b_project.id, domain_b_user.id, domain_b_role.id
+    ), (
+        f"Test setup error: assigning project-level to user "
+        f"'{domain_b_user.name}' for project '{domain_b_project.name}' "
+        f"as domain manager of domain '{domain_b.name}' failed but is "
+        f"required by the testing process; please check "
+        f"the test implementation and domain configuration"
+    )
+    # note that unassign_project_role_from_user() does not raise an exception
+    # if it fails; the result has to be checked explicitly
+    conn_a.identity.unassign_project_role_from_user(
+        domain_b_project.id, domain_b_user.id, domain_b_role.id
+    )
+    assert conn_b.identity.validate_user_has_project_role(
+        domain_b_project.id, domain_b_user.id, domain_b_role.id
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"unassign project-level role from user '{domain_b_user.name}' for "
+        f"project '{domain_b_project.name}' within foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot unassign project-level role from user within "
+          "foreign domain: PASS")
+
+    # [D1] domain manager cannot list projects for a user of foreign domain D2
+    #
+    # quirk: user_projects() returns a generator and only raises a
+    # ForbiddenException once the generator is iterated over the first time,
+    # hence calling next() on the return value of user_projects() will trigger
+    # the exception, not the user_projects() call itself
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        next,  # the function to be called
+        conn_a.identity.user_projects(domain_b_user.id)  # the argument
+    ), (
+        f"Policy error: domain manager of domain '{domain_a.name}' is able to "
+        f"list projects for user '{domain_b_user.name}' of foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot list projects for user of foreign domain: "
+          "PASS")
+
+
+def test_groups(cloud_name: str, domains: list[dict], prefix=DEFAULT_PREFIX):
+    """
+    Test correct domain scoping for domain managers relating to the groups
+    feature of Keystone.
+    """
+    print("\nExecuting tests for Keystone groups ...")
+
+    # 1st domain = D1
+    domain_a_name = domains[0].get("name")
+    conn_a = connect_to_domain(cloud_name, domain_a_name, domains)
+    domain_a = conn_a.identity.find_domain(domain_a_name)
+    domain_a_user = conn_a.identity.create_user(
+        name=f"{prefix}domain-a-user-1",
+        domain_id=domain_a.id
+    )
+    domain_a_project = conn_a.identity.create_project(
+        name=f"{prefix}domain-a-project-1",
+        domain_id=domain_a.id
+    )
+    domain_a_role = conn_a.identity.find_role(domains[0].get("member_role"))
+
+    # 2nd domain = D2
+    domain_b_name = domains[1].get("name")
+    conn_b = connect_to_domain(cloud_name, domain_b_name, domains)
+    domain_b = conn_b.identity.find_domain(domain_b_name)
+    domain_b_user = conn_b.identity.create_user(
+        name=f"{prefix}domain-b-user-1",
+        domain_id=domain_b.id
+    )
+
+    # [D1] group creation without specifying domain (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_group,
+        name=f"{prefix}group-outside-domain-a"
+    ), (
+        f"Policy error: domain manager is able to create group without "
+        f"specifying domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot create group without specifying domain: PASS")
+
+    # [D1] group creation in a foreign domain (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.create_group,
+        name=f"{prefix}group-in-wrong-domain",
+        domain_id=domain_b.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' is able to create "
+        f"group in foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot create group in foreign domain: PASS")
+
+    # [D1] group creation within domain
+    domain_a_group = conn_a.identity.create_group(
+        name=f"{prefix}group-inside-domain-a",
+        domain_id=domain_a.id
+    )
+    assert domain_a_group, (
+        f"Domain manager cannot create groups within domain '{domain_a.name}'"
+    )
+    print("Domain manager can create group within domain: PASS")
+
+    # [D2] domain manager does not see group of foreign domain D1
+    domain_a_groups = conn_b.identity.groups()
+    assert next(domain_a_groups, None) is None, (
+        f"Policy error: domain manager of '{domain_b.name}' is able to see "
+        f"groups of foreign domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot see groups of foreign domain: PASS")
+
+    # [D2] domain manager cannot update group of foreign domain D1
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_b.identity.update_group,
+        domain_a_group.id,
+        name=f"{prefix}group-RENAMED"
+    ), (
+        f"Policy error: domain manager of '{domain_b.name}' is able to update "
+        f"group in foreign domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot update group in foreign domain: PASS")
+
+    # [D2] domain manager cannot delete group of foreign domain D1
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_b.identity.delete_group,
+        domain_a_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_b.name}' is able to delete "
+        f"group in foreign domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot delete group in foreign domain: PASS")
+
+    # [D2] group creation within domain (prerequisite for subsequent tests)
+    domain_b_group = conn_b.identity.create_group(
+        name=f"{prefix}group-inside-domain-b",
+        domain_id=domain_b.id
+    )
+    assert domain_b_group, (
+        f"Domain manager cannot create groups within domain '{domain_b.name}'"
+    )
+
+    # [D1] domain manager can query group relationship of user within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.check_user_in_group,
+        domain_a_user.id, domain_a_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' cannot use "
+        f"check_user_in_group within domain"
+    )
+    print("Domain manager can use check_user_in_group within domain: PASS")
+
+    # [D1] domain manager cannot query group relationship of user when
+    # group or user are in foreign domain D2 (negative test)
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.check_user_in_group,
+        domain_b_user.id, domain_a_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' is able to use "
+        f"check_user_in_group for user of foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot use check_user_in_group "
+          "for user of foreign domain: PASS")
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.check_user_in_group,
+        domain_a_user.id, domain_b_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' is able to use "
+        f"check_user_in_group for group of foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot use check_user_in_group "
+          "for group of foreign domain: PASS")
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.check_user_in_group,
+        domain_b_user.id, domain_b_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' is able to use "
+        f"check_user_in_group for user and group, both of foreign domain "
+        f"'{domain_b.name}'"
+    )
+    print("Domain manager cannot use check_user_in_group "
+          "for user and group of foreign domain: PASS")
+
+    # [D1] domain manager can add user to group within domain
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.add_user_to_group,
+        domain_a_user.id, domain_a_group.id
+    ), (
+        f"Policy error: domain manager cannot add user to group within domain "
+        f"'{domain_a.name}'"
+    )
+    assert conn_a.identity.check_user_in_group(
+        domain_a_user.id, domain_a_group.id
+    ), (
+        f"User '{domain_a_user.name}' was not successfully added to group "
+        f"'{domain_a_group.name}' in domain '{domain_a.name}'"
+    )
+    print("Domain manager can add user to group within domain: PASS")
+
+    # [D1] domain manager cannot add user to group across domain boundaries
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.add_user_to_group,
+        domain_a_user.id, domain_b_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' is able to add "
+        f"user to group belonging to foreign domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot add user to group of foreign domain: PASS")
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.add_user_to_group,
+        domain_b_user.id, domain_a_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' is able to add "
+        f"user belonging to foreign domain '{domain_b.name}' to group"
+    )
+    print("Domain manager cannot add user of foreign domain to group: PASS")
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.add_user_to_group,
+        domain_b_user.id, domain_b_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_a.name}' is able to add "
+        f"user belonging to foreign domain '{domain_b.name}' to group of foreign "
+        f" domain '{domain_b.name}'"
+    )
+    print("Domain manager cannot add user to group in foreign domain: PASS")
+
+    # [D1] domain manager can list users for group
+    assert not _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_a.identity.group_users,
+        domain_a_group.id
+    ), (
+        f"Policy error: domain manager cannot list users for group within "
+        f"domain '{domain_a.name}'"
+    )
+    users = list(conn_a.identity.group_users(domain_a_group.id))
+    assert len(users) == 1, (
+        f"Listing users of group '{domain_a_group.name}' within domain "
+        f"'{domain_a.name}' returned wrong amount of users"
+    )
+    assert users[0].name == domain_a_user.name, (
+        f"Listing users of group '{domain_a_group.name}' within domain "
+        f"'{domain_a.name}' returned wrong user"
+    )
+    print("Domain manager can list users for group in domain: PASS")
+
+    # [D1] domain manager cannot assign admin role to groups
+    # (do these tests before any other role assignment tests that might succeed
+    # because we expect assignment lists to be empty for the negative tests)
+    domain_a_project_2 = conn_a.identity.create_project(
+        name=f"{prefix}domain-a-project-2",
+        domain_id=domain_a.id
+    )
+    admin_role = conn_a.identity.find_role("admin")
+    assert admin_role is not None, (
+        f"Domain Manager of domain '{domain_a.name}' cannot discover the 'admin' "
+        f"role (which is used for negative testing)"
+    )
+    conn_a.identity.assign_project_role_to_group(
+        domain_a_project_2.id, domain_a_group.id, admin_role.id
+    )
+    # the assign_project_role_to_group() does not raise an exception but should
+    # not result in an active role assignment for the admin role
+    assigns = list(conn_a.identity.role_assignments(
+        scope_project_id=domain_a_project_2.id,
+        group_id=domain_a_group.id
+    ))
+    assert len(assigns) == 0, (
+        f"Domain Manager of domain '{domain_a.name}' is able to assign 'admin' "
+        f"role to group '{domain_a_group.name}' in project "
+        f"'{domain_a_project_2.name}'"
+    )
+    print("Domain manager cannot assign admin role to group on project level: "
+          "PASS")
+    conn_a.identity.assign_domain_role_to_group(
+        domain_a.id, domain_a_group.id, admin_role.id
+    )
+    # the assign_domain_role_to_group() does not raise an exception but should
+    # not result in an active role assignment for the admin role
+    assigns = list(conn_a.identity.role_assignments(
+        scope_domain_id=domain_a.id,
+        group_id=domain_a_group.id
+    ))
+    assert len(assigns) == 0, (
+        f"Domain Manager of domain '{domain_a.name}' is able to assign 'admin' "
+        f"role to group '{domain_a_group.name}' in domain"
+    )
+    print("Domain manager cannot assign admin role to group on domain level in "
+          "domain: PASS")
+
+    # [D1] domain manager can assign role to group within domain
+    # note that assign_domain_role_to_group() does not raise any exception if
+    # it fails; the result must be checked by querying resulting assignments
+    conn_a.identity.assign_domain_role_to_group(
+        domain_a.id, domain_a_group.id, domain_a_role.id
+    )
+    assigns = list(conn_a.identity.role_assignments(
+        scope_domain_id=domain_a.id,
+        group_id=domain_a_group.id,
+    ))
+    assert len(assigns) == 1 and assigns[0].role["id"] == domain_a_role.id, (
+        f"The domain role assignment for role '{domain_a_role.name}', domain "
+        f"'{domain_a.name}' and group '{domain_a_group.name}' was not successful"
+    )
+    print("Domain manager can assign domain-level role to group in domain: "
+          "PASS")
+
+    conn_a.identity.assign_project_role_to_group(
+        domain_a_project.id, domain_a_group.id, domain_a_role.id
+    )
+    assigns = list(conn_a.identity.role_assignments(
+        scope_project_id=domain_a_project.id,
+        group_id=domain_a_group.id
+    ))
+    assert len(assigns) == 1 and assigns[0].role["id"] == domain_a_role.id, (
+        f"The project role assignment for role '{domain_a_role.name}', "
+        f"project '{domain_a_project.name}' and group '{domain_a_group.name}' "
+        f"in domain '{domain_a.name}' was not successful"
+    )
+    print("Domain manager can assign project-level role to group in domain: "
+          "PASS")
+
+    # [D2] domain manager cannot unassign project-level role from group in
+    # foreign domain
+    # note that unassign_project_role_from_group() does not raise exceptions
+    # upon request failure, thus the result has to be verified through active
+    # role assignment checking
+    conn_b.identity.unassign_project_role_from_group(
+        domain_a_project.id, domain_a_group.id, domain_a_role
+    )
+    # use connection for D1 to check that the role assignment was not removed
+    assigns = list(conn_a.identity.role_assignments(
+        scope_project_id=domain_a_project.id,
+        group_id=domain_a_group.id
+    ))
+    assert len(assigns) == 1 and assigns[0].role["id"] == domain_a_role.id, (
+        f"Policy error: domain manager of domain '{domain_b.name}' is able to "
+        f"unassign project-level role from group within foreign domain "
+        f"'{domain_a.name}'"
+    )
+    print("Domain manager cannot unassign project-level role from group in "
+          "foreign domain: PASS")
+
+    # [D2] domain manager cannot unassign domain-level role from group in
+    # foreign domain
+    # note that unassign_domain_role_from_group() does not raise exceptions
+    # upon request failure, thus the result has to be verified through active
+    # role assignment checking
+    conn_b.identity.unassign_domain_role_from_group(
+        domain_a.id, domain_a_group.id, domain_a_role
+    )
+    # use connection for D1 to check that the role assignment was not removed
+    assigns = list(conn_a.identity.role_assignments(
+        scope_domain_id=domain_a.id,
+        group_id=domain_a_group.id
+    ))
+    assert len(assigns) == 1 and assigns[0].role["id"] == domain_a_role.id, (
+        f"Policy error: domain manager of domain '{domain_b.name}' is able to "
+        f"unassign domain-level role from group within foreign domain "
+        f"'{domain_a.name}'"
+    )
+    print("Domain manager cannot unassign domain-level role from group in "
+          "foreign domain: PASS")
+
+    # [D1] domain manager can revoke domain-level role from group within domain
+    conn_a.identity.unassign_domain_role_from_group(
+        domain_a.id, domain_a_group.id, domain_a_role
+    )
+    assigns = list(conn_a.identity.role_assignments(
+        scope_domain_id=domain_a.id,
+        group_id=domain_a_group.id
+    ))
+    assert len(assigns) == 0, (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot unassign "
+        f"domain-level role from group '{domain_a_group.name}' within domain"
+    )
+    print("Domain manager can unassign domain-level role from group in "
+          "domain: PASS")
+
+    # [D1] domain manager can revoke project-level role from group within domain
+    conn_a.identity.unassign_project_role_from_group(
+        domain_a_project.id, domain_a_group.id, domain_a_role
+    )
+    assigns = list(conn_a.identity.role_assignments(
+        scope_project_id=domain_a_project.id,
+        group_id=domain_a_group.id
+    ))
+    assert len(assigns) == 0, (
+        f"Policy error: domain manager of domain '{domain_a.name}' cannot unassign "
+        f"project-level role from group '{domain_a_group.name}' within domain"
+    )
+    print("Domain manager can unassign project-level role from group in "
+          "domain: PASS")
+
+    # [D2] domain manager cannot query user lists of groups of foreign domains
+    users_seen_by_a = list(conn_a.identity.group_users(domain_a_group.id))
+    assert len(users_seen_by_a) > 0, (
+        f"Test setup error: group '{domain_a_group.name}' of domain "
+        f"'{domain_a.name}' should have at least one user assigned, please check "
+        f"the test implementation order and domain configuration"
+    )
+    # quirk: group_users() returns a generator and only raises a
+    # ForbiddenException once the generator is iterated over the first time,
+    # hence calling next() on the return value of group_users() will trigger
+    # the exception, not the group_users() call itself
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        next,  # the function to be called
+        conn_b.identity.group_users(domain_a_group.id)  # the argument
+    ), (
+        f"Policy error: domain manager of '{domain_b.name}' is able to list "
+        f"users for group '{domain_a_group.name}' of foreign domain "
+        f"'{domain_a.name}'"
+    )
+    print("Domain manager cannot list users for group in foreign domain: PASS")
+
+    # [D2] domain manager cannot remove user from group in foreign domain
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_b.identity.remove_user_from_group,
+        domain_a_user.id, domain_a_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_b.name}' is able to remove "
+        f"user '{domain_a_user.name}' from group '{domain_a_group.name}' "
+        f"within foreign domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot remove user from group in foreign domain: "
+          "PASS")
+
+    # [D2] domain manager cannot delete group in foreign domain
+    assert _raisesException(
+        openstack.exceptions.ForbiddenException,
+        conn_b.identity.delete_group,
+        domain_a_group.id
+    ), (
+        f"Policy error: domain manager of '{domain_b.name}' is able to delete "
+        f"group '{domain_a_group.name}' of foreign domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot delete group in foreign domain: PASS")
+
+    # [D2] domain manager cannot assign role to group in foreign domain D1
+    #
+    # as conn_a create a dedicated group in D1 for this test without any roles
+    domain_a_group_2 = conn_a.identity.create_group(
+        name=f"{prefix}secondary-group-inside-domain-a",
+        domain_id=domain_a.id
+    )
+    # as conn_b attempt to add project-level role
+    conn_b.identity.assign_project_role_to_group(
+        domain_a_project.id, domain_a_group_2.id, domain_a_role.id
+    )
+    # as conn_a verify that no role assignment was added
+    assigns = list(conn_a.identity.role_assignments(
+        scope_project_id=domain_a_project.id,
+        group_id=domain_a_group_2.id
+    ))
+    assert len(assigns) == 0, (
+        f"Domain Manager of domain '{domain_b.name}' is able to assign "
+        f"project-level role to group '{domain_a_group_2.name}' in project "
+        f"'{domain_a_project.name}' of foreign domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot assign project-level role to group in "
+          "foreign domain: PASS")
+    # as conn_b attempt to add domain-level role
+    conn_b.identity.assign_domain_role_to_group(
+        domain_a.id, domain_a_group_2.id, domain_a_role.id
+    )
+    # as conn_a verify that no role assignment was added
+    assigns = list(conn_a.identity.role_assignments(
+        scope_domain_id=domain_a.id,
+        group_id=domain_a_group_2.id
+    ))
+    assert len(assigns) == 0, (
+        f"Domain Manager of domain '{domain_b.name}' is able to assign "
+        f"domain-level role to group '{domain_a_group_2.name}' within foreign "
+        f"domain '{domain_a.name}'"
+    )
+    print("Domain manager cannot assign domain-level role to group in "
+          "foreign domain: PASS")
+
+    # [D1] domain manager can delete group within domain
+    assert conn_a.identity.find_group(domain_a_group.id), (
+        f"Test setup error: group '{domain_a_group.name}' of domain "
+        f"'{domain_a.name}' should exist at this point, please check "
+        f"the test implementation order and domain configuration"
+    )
+    conn_a.identity.delete_group(domain_a_group.id)
+    assert conn_a.identity.find_group(domain_a_group.id) is None, (
+        f"Policy error: domain manager of '{domain_a.name}' cannot successfully "
+        f"delete group '{domain_a_group.name}' within domain"
+    )
+    print("Domain manager can delete group within domain: PASS")
+
+
+def main():
+    domain_yaml_path = "./domain-manager-test.yaml"
+    parser = argparse.ArgumentParser(
+        description="SCS Domain Manager Conformance Checker")
+    parser.add_argument(
+        "--os-cloud", type=str,
+        help="Name of the cloud from clouds.yaml, alternative "
+        "to the OS_CLOUD environment variable"
+    )
+    parser.add_argument(
+        "--domain-config", type=str,
+        help=f"Path to the YAML file containing the domain definitions and "
+        f"domain manager credentials for testing (default: {domain_yaml_path})"
+    )
+    parser.add_argument(
+        "--prefix", type=str,
+        default=DEFAULT_PREFIX,
+        help=f"OpenStack resource name prefix for all resources to be created "
+        f"and/or cleaned up by this script within the configured domains "
+        f"(default: '{DEFAULT_PREFIX}')"
+    )
+    parser.add_argument(
+        "--cleanup-only", action="store_true",
+        help="Instead of executing tests, cleanup all resources "
+        "with the prefix specified via '--prefix' (or its default) "
+        "within the defined domains"
+    )
+    parser.add_argument(
+        "--debug", action="store_true",
+        help="Enable OpenStack SDK debug logging"
+    )
+    args = parser.parse_args()
+    openstack.enable_logging(debug=args.debug)
+    prefix = args.prefix
+    if not prefix.endswith('-'):
+        prefix += '-'
+    if args.domain_config:
+        domain_yaml_path = args.domain_config
+
+    # parse cloud name for lookup in clouds.yaml
+    cloud = os.environ.get("OS_CLOUD", None)
+    if args.os_cloud:
+        cloud = args.os_cloud
+    assert cloud, (
+        "You need to have the OS_CLOUD environment variable set to your cloud "
+        "name or pass it via --os-cloud"
+    )
+
+    # load the domain test configuration
+    domains = load_domain_definitions(domain_yaml_path).get("domains")
+
+    if args.cleanup_only:
+        cleanup(cloud, domains, prefix=prefix)
+    else:
+        test_logins(cloud, domains)
+        cleanup(cloud, domains, prefix=prefix)
+        test_users(cloud, domains, prefix=prefix)
+        cleanup(cloud, domains, prefix=prefix)
+        test_projects(cloud, domains, prefix=prefix)
+        cleanup(cloud, domains, prefix=prefix)
+        test_groups(cloud, domains, prefix=prefix)
+        cleanup(cloud, domains, prefix=prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/iam/domain-manager/domain-manager-test.yaml
+++ b/Tests/iam/domain-manager/domain-manager-test.yaml
@@ -1,0 +1,11 @@
+domains:
+  - name: "scs-test-domain-a"
+    manager:
+      username: "scs-test-domain-a-manager"
+      password: "foobar123"
+    member_role: "member"
+  - name: "scs-test-domain-b"
+    manager:
+      username: "scs-test-domain-b-manager"
+      password: "foobar123"
+    member_role: "member"


### PR DESCRIPTION
Adds a standard for the Keystone API policy configuration to introduce the `domain-manager` role as per  SovereignCloudStack/issues#184

It includes extensions for Keystone groups and therefore closes SovereignCloudStack/issues#383