### PR TITLE
 [BUG] Incorrect 'type' header field in scs-0301-v1 #386

### DIFF
--- a/Standards/scs-0301-v1-naming-conventions.md
+++ b/Standards/scs-0301-v1-naming-conventions.md
@@ -1,6 +1,6 @@
 ---
-title: Recommended naming for domains/groups/roles/project when onboarding new customers
-type: _Standard | Decision Record_
+title: Naming for domains/groups/roles/project when onboarding new customers
+type: Decision Record
 status: Draft
 track: IAM
 ---


### PR DESCRIPTION
Fixed the 'type' and shorten the name of the naming ADR.