### PR TITLE
Adjust link validator action for daily checks

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,5 +1,16 @@
-on: [pull_request]
 name: Check links for modified files
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+  pull_request:   # Add this section
+    branches:
+      - main
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
run link validator daily on main, on pushes on main and on pull requests on main instead of only on pull requests.