### PR TITLE
Stabilize SCS-0210-v2

### DIFF
--- a/Standards/scs-0210-v1-k8s-new-version-policy.md
+++ b/Standards/scs-0210-v1-k8s-new-version-policy.md
@@ -1,8 +1,9 @@
 ---
 title: SCS K8S Version Policy for new Kubernetes versions
 type: Standard
-status: Stable
 stabilized_at: 2023-02-07
+obsoleted_at: 2024-02-08
+status: Deprecated
 track: KaaS
 description: |
   The SCS-0210 standard outlines the expected pace at which providers should adopt new Kubernetes versions, aiming

--- a/Standards/scs-0210-v2-k8s-version-policy.md
+++ b/Standards/scs-0210-v2-k8s-version-policy.md
@@ -1,8 +1,8 @@
 ---
 title: SCS K8S Version Policy
 type: Standard
-status: Stable
 stabilized_at: 2024-02-08
+status: Stable
 track: KaaS
 ---
 

--- a/Standards/scs-0210-v2-k8s-version-policy.md
+++ b/Standards/scs-0210-v2-k8s-version-policy.md
@@ -1,7 +1,8 @@
 ---
 title: SCS K8S Version Policy
 type: Standard
-status: Draft
+status: Stable
+stabilized_at: 2024-02-08
 track: KaaS
 ---
 


### PR DESCRIPTION
Stabilizes standard SCS-0210-v2 for the next certificate scopes.
Deprecates standard SCS-0210-v1 for the next certificate scopes.