### PR TITLE
Discussion about obsoleted_at and deprecated_at

### DIFF
--- a/Standards/scs-0001-v1-sovereign-cloud-standards.md
+++ b/Standards/scs-0001-v1-sovereign-cloud-standards.md
@@ -110,7 +110,7 @@ embedded in the markdown header.
 | `status`        | REQUIRED                                                                   | one of `Proposal`, `Draft`, `Stable`, `Deprecated`, or `Rejected`                     |
 | `track`         | REQUIRED                                                                   | one of `Global`, `IaaS`, `KaaS`, `IAM`, `Ops`                                         |
 | `supplements`   | REQUIRED precisely when `type` is `Supplement`                             | list of documents that are extended by this document (e.g., multiple major versions)  |
-| `obsoleted_at`  | REQUIRED if `status` is `Deprecated`                                       | ISO formatted date indicating the date after which the deprecation is in effect       |
+| `deprecated_at`  | REQUIRED if `status` is `Deprecated`                                       | ISO formatted date indicating the date after which the deprecation is in effect       |
 | `stabilized_at` | REQUIRED if `status` was ever `Stable`                                     | ISO formatted date indicating the date after which the document was considered stable |
 | `rejected_at`   | REQUIRED if `status` is `Rejected`                                         | ISO formatted date indicating the date on which the document was rejected             |
 | `replaced_by`   | RECOMMENDED if `status` is `Deprecated` or `Rejected`, FORBIDDEN otherwise | List of documents which replace this document.                                        |

--- a/Standards/scs-0003-v1-sovereign-cloud-standards-yaml.md
+++ b/Standards/scs-0003-v1-sovereign-cloud-standards-yaml.md
@@ -116,12 +116,12 @@ then a certificate of that prerequisite scope has to be presented before the cer
 | `version`       | String        | Mandatory: Version of the particular list of standards                          | _v3_         |
 | `standards`     | Array of maps | Mandatory: List of standard descriptors for this particular layer               |              |
 | `stabilized_at` | Date          | ISO formatted date indicating the date after this version is considered stable. | _2022-11-09_ |
-| `obsoleted_at`  | Date          | ISO formatted date indicating the date on which this version is expired.        | _2023-04-09_ |
+| `deprecated_at`  | Date          | ISO formatted date indicating the date on which this version is expired.        | _2023-04-09_ |
 
-Once a version has a `stabilized_at` field, this field may not be changed. The same holds true for the `obsoleted_at` field.
+Once a version has a `stabilized_at` field, this field may not be changed. The same holds true for the `deprecated_at` field.
 
 Note that at any point in time, all versions that are older (`stabilized_at` is at or before this point)
-can be certified against, unless the version is already obsoleted (the point is after `obsoleted_at`).
+can be certified against, unless the version is already deprecated (the point is after `deprecated_at`).
 This means that more than one version may be allowable at a certain point in time. Tooling should default
 to use the newest allowable version (the one with the most recent `stabilized_at` date) then.
 
@@ -191,13 +191,13 @@ versions:
 
   - version: v3 # This is the stable set of standards that is currently active
     stabilized_at: 2021-10-01
-    obsoleted_at: 2022-11-08
+    deprecated_at: 2022-11-08
     standards:
       - name: ....
 
   - version: v2 # This set of standards is obsolete and has been replaced by v3
     stabilized_at: 2021-07-01
-    obsoleted_at: 2021-11-01
+    deprecated_at: 2021-11-01
     standards:
       - name: ....
 ```

--- a/Standards/scs-0100-v1-flavor-naming.md
+++ b/Standards/scs-0100-v1-flavor-naming.md
@@ -7,7 +7,7 @@ track: IaaS
 status: Deprecated
 state: v1.1 (for R3)
 stabilized_at: 2022-09-08
-obsoleted_at: 2023-10-31
+deprecated_at: 2023-10-31
 ---
 
 ## Introduction

--- a/Standards/scs-0100-v2-flavor-naming.md
+++ b/Standards/scs-0100-v2-flavor-naming.md
@@ -5,7 +5,7 @@ status: Deprecated
 track: IaaS
 replaces: scs-0100-v1-flavor-naming.md
 stabilized_at: 2023-02-21
-obsoleted_at: 2023-11-30
+deprecated_at: 2023-11-30
 ---
 
 ## Introduction

--- a/Standards/scs-0210-v1-k8s-new-version-policy.md
+++ b/Standards/scs-0210-v1-k8s-new-version-policy.md
@@ -2,7 +2,7 @@
 title: SCS K8S Version Policy for new Kubernetes versions
 type: Standard
 stabilized_at: 2023-02-07
-obsoleted_at: 2024-02-08
+deprecated_at: 2024-02-08
 status: Deprecated
 track: KaaS
 description: |

--- a/Tests/chk_adrs.py
+++ b/Tests/chk_adrs.py
@@ -18,7 +18,7 @@ import yaml
 # | `type`          | REQUIRED                                                                   | one of `Procedural`, `Standard`, or `Decision Record`                                 |
 # | `status`        | REQUIRED                                                                   | one of `Proposal`, `Draft`, `Stable`, `Deprecated`, or `Rejected`                     |
 # | `track`         | REQUIRED                                                                   | one of `Global`, `IaaS`, `KaaS`, `IAM`, `Ops`                                         |
-# | `deprecated_at`  | REQUIRED if `status` is `Deprecated`                                       | ISO formatted date indicating the date after which the deprecation is in effect       |
+# | `deprecated_at` | REQUIRED if `status` is `Deprecated`                                       | ISO formatted date indicating the date after which the deprecation is in effect       |
 # | `stabilized_at` | REQUIRED if `status` was ever `Stable`                                     | ISO formatted date indicating the date after which the document was considered stable |
 # | `rejected_at`   | REQUIRED if `status` is `Rejected`                                         | ISO formatted date indicating the date on which the document was rejected             |
 # | `replaced_by`   | RECOMMENDED if `status` is `Deprecated` or `Rejected`, FORBIDDEN otherwise | List of documents which replace this document.                                        |

--- a/Tests/chk_adrs.py
+++ b/Tests/chk_adrs.py
@@ -18,7 +18,7 @@ import yaml
 # | `type`          | REQUIRED                                                                   | one of `Procedural`, `Standard`, or `Decision Record`                                 |
 # | `status`        | REQUIRED                                                                   | one of `Proposal`, `Draft`, `Stable`, `Deprecated`, or `Rejected`                     |
 # | `track`         | REQUIRED                                                                   | one of `Global`, `IaaS`, `KaaS`, `IAM`, `Ops`                                         |
-# | `obsoleted_at`  | REQUIRED if `status` is `Deprecated`                                       | ISO formatted date indicating the date after which the deprecation is in effect       |
+# | `deprecated_at`  | REQUIRED if `status` is `Deprecated`                                       | ISO formatted date indicating the date after which the deprecation is in effect       |
 # | `stabilized_at` | REQUIRED if `status` was ever `Stable`                                     | ISO formatted date indicating the date after which the document was considered stable |
 # | `rejected_at`   | REQUIRED if `status` is `Rejected`                                         | ISO formatted date indicating the date on which the document was rejected             |
 # | `replaced_by`   | RECOMMENDED if `status` is `Deprecated` or `Rejected`, FORBIDDEN otherwise | List of documents which replace this document.                                        |
@@ -44,7 +44,7 @@ FRONT_MATTER_KEYS = {
     "type": ("Procedural", "Standard", "Decision Record").__contains__,
     "status": ("Proposal", "Draft", "Stable", "Deprecated", "Rejected").__contains__,
     "track": ("Global", "IaaS", "KaaS", "IAM", "Ops").__contains__,
-    "obsoleted_at": optional(iso_date),
+    "deprecated_at": optional(iso_date),
     "stabilized_at": optional(iso_date),
     "rejected_at": optional(iso_date),
 }
@@ -116,7 +116,7 @@ class Checker:
         status = front.get("status")
         if "replaced_by" in front and status not in ("Deprecated", "Rejected"):
             self.emit(f"in {fn}: replaced_by is set, but status does not match")
-        if status == "Deprecated" and "obsoleted_at" not in front:
+        if status == "Deprecated" and "deprecated_at" not in front:
             self.emit(f"in {fn}: status is Deprecated, but deprecated_at date is missing")
         if status in ("Stable", "Deprecated") and "stabilized_at" not in front:
             self.emit(f"in {fn}: status is Stable or Deprecated, but stabilized_at date is missing")

--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -37,7 +37,7 @@ versions:
             args: -c {os_cloud} -d ./iaas/scs-0104-v1-images.yaml
   - version: v3
     stabilized_at: 2023-06-15
-    obsoleted_at: 2024-04-30
+    deprecated_at: 2024-04-30
     standards:
       - name: Flavor naming
         url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0100-v3-flavor-naming.md
@@ -54,7 +54,7 @@ versions:
         url: https://opendev.org/openinfra/interop/src/branch/master/guidelines/2022.11.json
   - version: v2
     stabilized_at: 2023-03-23
-    obsoleted_at: 2023-11-30
+    deprecated_at: 2023-11-30
     standards:
       - name: Flavor naming
         url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0100-v2-flavor-naming.md
@@ -70,7 +70,7 @@ versions:
         url: https://opendev.org/openinfra/interop/src/branch/master/guidelines/2022.11.json
   - version: v1
     stabilized_at: 2021-01-01
-    obsoleted_at: 2023-10-31
+    deprecated_at: 2023-10-31
     standards:
       - name: Flavor naming
         url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0100-v1-flavor-naming.md

--- a/Tests/scs-compliance-check.py
+++ b/Tests/scs-compliance-check.py
@@ -34,7 +34,7 @@ import yaml
 # valid keywords for various parts of the spec, to be checked using `check_keywords`
 KEYWORDS = {
     'spec': ('name', 'url', 'versions', 'prerequisite', 'variables'),
-    'version': ('version', 'standards', 'stabilized_at', 'obsoleted_at'),
+    'version': ('version', 'standards', 'stabilized_at', 'deprecated_at'),
     'standard': ('check_tools', 'url', 'name', 'condition'),
     'checktool': ('executable', 'env', 'args', 'condition', 'classification'),
 }
@@ -237,9 +237,9 @@ def main(argv):
     for vd in spec["versions"]:
         check_keywords('version', vd)
         stb_date = vd.get("stabilized_at")
-        obs_date = vd.get("obsoleted_at")
+        dep_date = vd.get("deprecated_at")
         futuristic = not stb_date or config.checkdate < stb_date
-        outdated = obs_date and obs_date < config.checkdate
+        outdated = dep_date and dep_date < config.checkdate
         vr = vrs[vd["version"]] = {
             "status": outdated and "outdated" or futuristic and "preview" or "valid",
             "passed": False,

--- a/Tests/testing/scs-compatible-test.yaml
+++ b/Tests/testing/scs-compatible-test.yaml
@@ -29,7 +29,7 @@ versions:
         # Unfortunately, no wrapper to run refstack yet, needs to be added
   - version: v3
     stabilized_at: 2023-06-15
-    obsoleted_at: 2024-04-30
+    deprecated_at: 2024-04-30
     standards:
       - name: Flavor naming
         url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0100-v3-flavor-naming.md
@@ -48,7 +48,7 @@ versions:
         # Unfortunately, no wrapper to run refstack yet, needs to be added
   - version: v2
     stabilized_at: 2023-03-20
-    obsoleted_at: 2024-04-30
+    deprecated_at: 2024-04-30
     standards:
       - name: Flavor naming
         url: https://github.com/SovereignCloudStack/standards/blob/main/Standards/scs-0100-v2-flavor-naming.md
@@ -64,7 +64,7 @@ versions:
         condition: mandatory
   - version: v1
     stabilized_at: 2021-01-01
-    obsoleted_at: 2023-10-30
+    deprecated_at: 2023-10-30
     standards:
       - name: Flavor naming
         url: https://github.com/SovereignCloudStack/standards/blob/main/Standards/scs-0100-v2-flavor-naming.md


### PR DESCRIPTION
SCS-0001 defines deprecation (and deprecated_at) as the keywords for deprecated or obsolete standards, that are most of the time succeeded by newer versions.
This MR replaces the obsoleted_at strings with deprecated_at defined by the initial standard.