### PR TITLE
Use an absolute path to locate the standard mandatory flavors.yaml file

### DIFF
--- a/Tests/iaas/flavor-naming/flavor_names.py
+++ b/Tests/iaas/flavor-naming/flavor_names.py
@@ -3,6 +3,7 @@ import os
 import os.path
 import re
 import sys
+from pathlib import Path
 from typing import Optional
 
 import yaml
@@ -10,6 +11,7 @@ import yaml
 
 CPUTYPE_KEY = {'L': 'crowded-core', 'V': 'shared-core', 'T': 'dedicated-thread', 'C': 'dedicated-core'}
 DISKTYPE_KEY = {'n': 'network', 'h': 'hdd', 's': 'ssd', 'p': 'nvme'}
+HERE = Path(__file__).parent
 
 
 class TypeCheck:
@@ -628,7 +630,7 @@ class CompatLayer:
         self.disallow_old = False
         self.prefer_old = False
         self.v3_flv = False
-        self.mandFlavorFile = "SCS-Spec.MandatoryFlavors.yaml"
+        self.mandFlavorFile = str(Path(HERE.parent, "SCS-Spec.MandatoryFlavors.yaml"))
         bindir = os.path.basename(sys.argv[0])
         self.searchpath = (bindir, ) if bindir else os.environ['PATH'].split(':')
 
@@ -667,9 +669,9 @@ class CompatLayer:
 
     def findflvfile(self, fnm):
         """Search for flavor file and return found path"""
-        searchpath = (".", "..", *self.searchpath, self.searchpath[0] + "/..", '/opt/share/SCS')
-        if os.path.dirname(fnm):
+        if os.path.isabs(fnm) or os.path.dirname(fnm):
             return fnm
+        searchpath = (".", "..", *self.searchpath, self.searchpath[0] + "/..", '/opt/share/SCS')
         for spath in searchpath:
             tnm = os.path.join(spath, fnm)
             if self.debug:

--- a/Tests/iaas/flavor-naming/flavor_names.py
+++ b/Tests/iaas/flavor-naming/flavor_names.py
@@ -669,15 +669,8 @@ class CompatLayer:
 
     def findflvfile(self, fnm):
         """Search for flavor file and return found path"""
-        if os.path.isabs(fnm) or os.path.dirname(fnm):
+        if os.path.isfile(fnm):
             return fnm
-        searchpath = (".", "..", *self.searchpath, self.searchpath[0] + "/..", '/opt/share/SCS')
-        for spath in searchpath:
-            tnm = os.path.join(spath, fnm)
-            if self.debug:
-                print(f"Search {tnm}")
-            if os.access(tnm, os.R_OK):
-                return tnm
         raise RuntimeError(f"Flavor yaml file not found: {fnm}")
 
     def readflavors(self, fnm, v3mode):

--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -10,7 +10,7 @@ versions:
         url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0100-v3-flavor-naming.md
         check_tools:
           - executable: ./iaas/flavor-naming/flavor-names-openstack.py
-            args: "--mand=./iaas/scs-0100-v3-flavors.yaml"
+            args: -2 "--mand=./iaas/scs-0100-v3-flavors.yaml"
       - name: Entropy
         url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0101-v1-entropy.md
         check_tools:


### PR DESCRIPTION
Fixes #479 