### PR TITLE
Expand status-page-openapi-spec-decision with severity levels

### DIFF
--- a/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
+++ b/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
@@ -90,11 +90,14 @@ Furthermore, a `SeverityValue` MUST be supplied to the `Impact` when referencing
 
 ### Severity
 
-A severity contains a name, that MUST be unique and WILL be used as identifier. The value marks the upper boundary of the severity.
+A severity contains a name, that MUST be unique and will be used as identifier. The `SeverityValue` marks the upper boundary of the severity.
 
 The severity's value range is calculated by taking the previous severity's (`SeverityA`) value and adding 1 to obtain the starting point and taking the current severity's (SeverityB) value as the end point. These limits are inclusive.
 
-`SeverityA.value + 1 <= Severity <= SeverityB.value`
+```acsii
+0, ... , SeverityA.value, SeverityA.value, + 1, ... , SeverityB.value - 1, SeverityB.value, SeverityB.value + 1, ... , 100
+                        |<------------range of severity values for SeverityB------------->|
+```
 
 Example:
 

--- a/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
+++ b/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
@@ -43,7 +43,7 @@ An `Incremental` is used in combination with other identifiers to identify a sub
 
 #### SeverityValue
 
-A `SeverityValue` is an unsiged integer ranging from 0 to 100 inclusively. It MUST be utilized by an `Impact` when referencing a `Component` to gauge the severity of the impact on that component. It MUST NOT be added to an `Impact` when referencing an `Incident`. While being described as an unsiged integer, implementing this value MAY not require it to be an uint data type in any form, because its range even fits in a signed int8 (byte) data type.
+A `SeverityValue` is an unsiged integer ranging from 0 to 100 inclusively. It MUST be utilized by an `Impact` when referenced by a `Component` to gauge the severity of the impact on that component. It MUST NOT be added to an `Impact` when referenced by an `Incident`. While being described as an unsiged integer, implementing this value MAY not require it to be an uint data type in any form, because its range even fits in a signed int8 (byte) data type.
 
 ### API objects
 
@@ -86,7 +86,7 @@ An impact defines the relation between an incident and a component. A component 
 
 To reflect this, each component and incident can have a list of impacts, stating the type of impact and a reference to the incident or component, it refers to.
 
-Furthermore, a `SeverityValue` MUST be supplied to the `Impact` when referencing a `Component`, to gauge the impact's severity on that component.
+Furthermore, a `SeverityValue` MUST be supplied to the `Impact` when referenced by a `Component`, to gauge the impact's severity on that component.
 
 ### Severity
 

--- a/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
+++ b/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
@@ -43,7 +43,7 @@ An `Incremental` is used in combination with other identifiers to identify a sub
 
 #### SeverityValue
 
-A `SeverityValue` is an unsiged integer ranging from 0 to 100 inclusively. It SHOULD be utilized by an `Impact` when referencing a `Component` to gauge the severity of the impact on that component. While being described as an unsiged integer implementing this value MAY not require it to be an uint data type in any form, because it range even fits in a signed int8 (byte) data type.
+A `SeverityValue` is an unsiged integer ranging from 0 to 100 inclusively. It MUST be utilized by an `Impact` when referencing a `Component` to gauge the severity of the impact on that component. It MUST NOT be added to an `Impact` when referencing an `Incident`. While being described as an unsiged integer, implementing this value MAY not require it to be an uint data type in any form, because its range even fits in a signed int8 (byte) data type.
 
 ### API objects
 
@@ -86,7 +86,7 @@ An impact defines the relation between an incident and a component. A component 
 
 To reflect this, each component and incident can have a list of impacts, stating the type of impact and a reference to the incident or component, it refers to.
 
-Furthermore, a `SeverityValue` SHOULD be added to the `Impact` when referencing a component, to gauge the impact's severity on that component.
+Furthermore, a `SeverityValue` MUST be supplied to the `Impact` when referencing a `Component`, to gauge the impact's severity on that component.
 
 ### Severity
 

--- a/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
+++ b/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
@@ -82,15 +82,15 @@ An impact defines the relation between an incident and a component. A component 
 
 To reflect this, each component and incident can have a list of impacts, stating the type of impact and a reference to the incident or component, it refers to.
 
-Furthermore a severity value is added to the impact when referencing an component, to gauge the impacts severity on the system.
+Furthermore, a `SeverityValue` is added to the `Impact` when referencing a component, to gauge the impact's severity on that component.
 
 ### Severity
 
 A severity contains a name, that MUST be unique and WILL be used as identifier. The value marks the upper boundary of the severity.
 
-The severity value range is calculated by the previous severitys (SeverityA) value + 1 to the current severitys (SeverityB) value. These limits are inclusive.
+The severity's value range is calculated by taking the previous severity's (`SeverityA`) value and adding 1 to obtain the starting point and taking the current severity's (SeverityB) value as the end point. These limits are inclusive.
 
-`SeverityA.value + 1 <=Severity <=SeverityB.value`
+`SeverityA.value + 1 <= Severity <= SeverityB.value`
 
 Example:
 
@@ -101,7 +101,7 @@ Example:
     "value": 10
   },
   {
-    "displayName": "Restricted",
+    "displayName": "Limited",
     "value": 50
   },
   {
@@ -114,13 +114,12 @@ Example:
 This means:
 
 - Operational from 0 to 10
-- Restriced from 11 to 50
+- Limited from 11 to 50
 - Broken from 51 to 100.
 
 A value of 100 is the maximum of the severity value.
 
-A severity with the value of 100 MUST always be supplied. This is the heighest severty for the system. If no severty with the 100 value exists, e.g. heighest severty value is 90, an `Impact` with a heigher severity
-WILL be handled as an unkown severity.
+A severity with the value of 100 MUST always be supplied. This is the highest severity for the system. If no severity with a value of 100 exists, e.g. the highest severity value is set at 90, an `Impact` with a higher `SeverityValue` WILL be considered to be an _unkown_ severity.
 
 ### Component impacts
 

--- a/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
+++ b/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
@@ -41,6 +41,10 @@ An `Incremental` is used in combination with other identifiers to identify a sub
 
 `Generation` and `Order` are predefined objects which include a `Incremental` typed field for the common usages of the `Incremental` value.
 
+#### SeverityValue
+
+A `SeverityValue` is an unsiged integer ranging from 0 to 100 inclusively. It SHOULD be utilized by an `Impact` when referencing a `Component` to gauge the severity of the impact on that component. While being described as an unsiged integer implementing this value MAY not require it to be an uint data type in any form, because it range even fits in a signed int8 (byte) data type.
+
 ### API objects
 
 All objects which are used as payload, either as request or response, are defined by schemas. This centralizes the maintanence of field names and types, for both requests and responses.
@@ -82,7 +86,7 @@ An impact defines the relation between an incident and a component. A component 
 
 To reflect this, each component and incident can have a list of impacts, stating the type of impact and a reference to the incident or component, it refers to.
 
-Furthermore, a `SeverityValue` is added to the `Impact` when referencing a component, to gauge the impact's severity on that component.
+Furthermore, a `SeverityValue` SHOULD be added to the `Impact` when referencing a component, to gauge the impact's severity on that component.
 
 ### Severity
 

--- a/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
+++ b/Standards/scs-0402-v1-status-page-openapi-spec-decision.md
@@ -82,6 +82,46 @@ An impact defines the relation between an incident and a component. A component 
 
 To reflect this, each component and incident can have a list of impacts, stating the type of impact and a reference to the incident or component, it refers to.
 
+Furthermore a severity value is added to the impact when referencing an component, to gauge the impacts severity on the system.
+
+### Severity
+
+A severity contains a name, that MUST be unique and WILL be used as identifier. The value marks the upper boundary of the severity.
+
+The severity value range is calculated by the previous severitys (SeverityA) value + 1 to the current severitys (SeverityB) value. These limits are inclusive.
+
+`SeverityA.value + 1 <=Severity <=SeverityB.value`
+
+Example:
+
+```json
+[
+  {
+    "displayName": "Operational",
+    "value": 10
+  },
+  {
+    "displayName": "Restricted",
+    "value": 50
+  },
+  {
+    "displayName": "Broken",
+    "value": 100
+  }
+]
+```
+
+This means:
+
+- Operational from 0 to 10
+- Restriced from 11 to 50
+- Broken from 51 to 100.
+
+A value of 100 is the maximum of the severity value.
+
+A severity with the value of 100 MUST always be supplied. This is the heighest severty for the system. If no severty with the 100 value exists, e.g. heighest severty value is 90, an `Impact` with a heigher severity
+WILL be handled as an unkown severity.
+
 ### Component impacts
 
 Components list their impacts, which they are affected by, as read only. Only an incident creates an impact on a component. Components MUST only list their currently active impacts.


### PR DESCRIPTION
Impacts might have different severities on a systems component. For the further development of the `status-page-web` project, these severities must be defined on the API service.