### PR TITLE
Update label in node distribution test (issues/#540)

### DIFF
--- a/Tests/kaas/k8s-node-distribution/k8s-node-distribution-check.py
+++ b/Tests/kaas/k8s-node-distribution/k8s-node-distribution-check.py
@@ -222,7 +222,7 @@ async def main(argv):
     labels = (
         "topology.kubernetes.io/region",
         "topology.kubernetes.io/zone",
-        "topology.scs.openstack.org/host-id",
+        "topology.scs.community/host-id",
     )
 
     nodes = await get_k8s_cluster_labelled_nodes(config.kubeconfig, labels + ("node-role.kubernetes.io/control-plane", ))


### PR DESCRIPTION
Update the label topology.scs.openstack.org/host-id in the node distribution test to topology.scs.community/host-id.