### PR TITLE
Simplify PR markdown lint workflow and fix deprecation warnings

### DIFF
--- a/.github/workflows/pr-markdownlint.yml
+++ b/.github/workflows/pr-markdownlint.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: npm
-          cache-dependency-path:  package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install all npm packages
         run: npm ci

--- a/.github/workflows/pr-markdownlint.yml
+++ b/.github/workflows/pr-markdownlint.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .nvmrc
       - package-lock.json
+      - .github/workflows/pr-markdownlint.yml
       - "**/*.md"
 
 jobs:

--- a/.github/workflows/pr-markdownlint.yml
+++ b/.github/workflows/pr-markdownlint.yml
@@ -15,20 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Get changed files
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          # Use the GitHub API to get the list of changed files
-          # documenation: https://docs.github.com/rest/commits/commits#compare-two-commits
-          DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${{ env.BASE_SHA }}...${{ env.HEAD_SHA }} \
-            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
-          # filter out files that are not markdown
-          DIFF_DOCUMENTS=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.md$" | xargs)
-          echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_ENV
-
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
@@ -36,10 +22,8 @@ jobs:
           cache: npm
           cache-dependency-path:  package-lock.json
 
-
       - name: Install all npm packages
         run: npm ci
 
       - name: Lint markdown files
-        run: |
-          npm run lint:md $DIFF_DOCUMENTS
+        run: npm run lint:md

--- a/.github/workflows/pr-markdownlint.yml
+++ b/.github/workflows/pr-markdownlint.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - .nvmrc
+      - package-lock.json
       - "**/*.md"
 
 jobs:


### PR DESCRIPTION
The computation of `$DIFF_DOCUMENTS` is futile, because in `package.json` the list `**/*.md` is hardcoded and all markdown files are linted anyways. I also think this is the better approach for the CI, so I propose this simplification.

Furthermore I changed the workflow to run

* when `package-lock.json` is changed, because this could mean the linter was updated and new linter versions might have a different opinion on style,
* when the workflow file itself is changed.

Also see #549.