### PR TITLE
Add k8s v1.30 to k8s-version-policy

### DIFF
--- a/Tests/kaas/k8s-version-policy/k8s-eol-data.yml
+++ b/Tests/kaas/k8s-version-policy/k8s-eol-data.yml
@@ -1,5 +1,7 @@
 # https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches
 
+- branch: '1.30'
+  end-of-life: '2025-06-28'
 - branch: '1.29'
   end-of-life: '2025-02-28'
 - branch: '1.28'


### PR DESCRIPTION
`ERROR: The K8s cluster version 1.30.1 of cluster 'test-cluster-admin@test-cluster' is already EOL.` - see https://github.com/SovereignCloudStack/cluster-stacks/pull/53#issuecomment-2145434140

AFAIK 1.30.1 is the Latest and not EOL.