### PR TITLE
Update auth_url endpoint and app credential id for poc-wgcloud

### DIFF
--- a/.github/scs-compliance-check/openstack/clouds.yaml
+++ b/.github/scs-compliance-check/openstack/clouds.yaml
@@ -80,5 +80,4 @@ clouds:
     #region_name: default
     auth:
       auth_url: https://identity.l1a.cloudandheat.com/v3
-      application_credential_id: "b4844a0fb23247149997bf0ff2c0b156"
-      #project_id: 9adb8fc81ba345178654cee5cb7f1464
+      application_credential_id: "7ab4e3339ea04255bc131868974cfe63"

--- a/.github/scs-compliance-check/openstack/clouds.yaml
+++ b/.github/scs-compliance-check/openstack/clouds.yaml
@@ -79,6 +79,6 @@ clouds:
     auth_type: "v3applicationcredential"
     #region_name: default
     auth:
-      auth_url: https://identity.l1.cloudandheat.com/v3
+      auth_url: https://identity.l1a.cloudandheat.com/v3
       application_credential_id: "b4844a0fb23247149997bf0ff2c0b156"
       #project_id: 9adb8fc81ba345178654cee5cb7f1464


### PR DESCRIPTION
The endpoint changed, we now use `l1a` instead of `l1` in the URL.