### PR TITLE
GitHub actions based DCO check

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         cache: 'pip'

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,27 @@
+# Based on the example described in:
+#   https://github.com/christophebedard/dco-check/blob/master/README.md#github
+# plus version pinning and caching.
+
+name: DCO check
+
+on: push
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Check DCO
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        pip3 install dco-check==0.4.0
+        dco-check


### PR DESCRIPTION
As a (maybe temporary) workaround for the currently malfunctioning DCO check.

Downside: this action has to be added to every repository in the org – in other words, this PR fixes only the `standards` repo.

The DCO app "required status check" must be disabled in the ["Branches" settings of this repo](https://github.com/SovereignCloudStack/standards/settings/branches).