### PR TITLE
Bugfix: secret key file only works with final newline

### DIFF
--- a/playbooks/pre_cloud.yaml
+++ b/playbooks/pre_cloud.yaml
@@ -21,7 +21,8 @@
 
     - name: Create ssh key file
       ansible.builtin.copy:
-        content: "{{ clouds_conf[secret_key] }}"
+        # the secrets are usually stripped of whitespace, but the final newline is essential here
+        content: "{{ clouds_conf[secret_key] + '\n' }}"
         dest: "~/id_subject"
         mode: "0600"
 


### PR DESCRIPTION
unfortunately, the error message given by ssh-keygen was just 'No such file or directory'