### PR TITLE
Fix script path to node distribution check

### DIFF
--- a/Tests/scs-compatible-kaas.yaml
+++ b/Tests/scs-compatible-kaas.yaml
@@ -31,6 +31,6 @@ versions:
       - name: Kubernetes node distribution and availability
         url: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0214-v1-k8s-node-distribution.md
         checks:
-          - executable: ./kaas/k8s-node-distribution/k8s-node-distribution-check.py
+          - executable: ./kaas/k8s-node-distribution/k8s_node_distribution_check.py
             args: -k {kubeconfig}
             id: node-distribution-check


### PR DESCRIPTION
Fixes error in Zuul E2E tests:

```
...
*******************************************************
Testing standard Kubernetes node distribution and availability ...
Reference: https://raw.githubusercontent.com/SovereignCloudStack/standards/main/Standards/scs-0214-v1-k8s-node-distribution.md ...

CRITICAL: [Errno 2] No such file or directory: '/home/ubuntu/scs-compliance/Tests/kaas/k8s-node-distribution/k8s-node-distribution-check.py'
... returned 0 errors, 1 aborts
*******************************************************
Verdict for subject KaaS_V2, SCS Compatible KaaS, version v1: 1 ERRORS
...
```

(from https://zuul.scs.community/t/SCS/buildset/a57242de6c4d4f6cade0ddb707623a6c)