### PR TITLE
Run pre-check cleanup also in GH actions

### DIFF
--- a/.github/workflows/scs-compliance-check-with-application-credential.yml
+++ b/.github/workflows/scs-compliance-check-with-application-credential.yml
@@ -32,6 +32,8 @@ jobs:
               auth:
                 application_credential_secret: ${{ secrets[inputs.secret_name] }}
           EOF
+      - name: "Clean up any lingering resources from previous run"
+        run: "cd /scs-compliance && ./cleanup.py -c ${{ inputs.cloud }} --prefix _scs-"
       - name: "Run scs-compliance-check"
         run: "cd /scs-compliance && ./scs-compliance-check.py scs-compatible-${{ inputs.layer }}.yaml --version ${{ inputs.version }} -o result.yaml -s ${{ inputs.cloud }} -a os_cloud=${{ inputs.cloud }}"
       - name: "Upload results"

--- a/.github/workflows/scs-compliance-check-with-application-credential.yml
+++ b/.github/workflows/scs-compliance-check-with-application-credential.yml
@@ -33,6 +33,7 @@ jobs:
                 application_credential_secret: ${{ secrets[inputs.secret_name] }}
           EOF
       - name: "Clean up any lingering resources from previous run"
+        if: ${{ inputs.layer == 'iaas' && inputs.version == 'v4' }}
         run: "cd /scs-compliance && ./cleanup.py -c ${{ inputs.cloud }} --prefix _scs-"
       - name: "Run scs-compliance-check"
         run: "cd /scs-compliance && ./scs-compliance-check.py scs-compatible-${{ inputs.layer }}.yaml --version ${{ inputs.version }} -o result.yaml -s ${{ inputs.cloud }} -a os_cloud=${{ inputs.cloud }}"

--- a/.github/workflows/scs-compliance-check.yml
+++ b/.github/workflows/scs-compliance-check.yml
@@ -33,6 +33,7 @@ jobs:
                 password: ${{ secrets[inputs.secret_name] }}
           EOF
       - name: "Clean up any lingering resources from previous run"
+        if: ${{ inputs.layer == 'iaas' && inputs.version == 'v4' }}
         run: "cd /scs-compliance && ./cleanup.py -c ${{ inputs.cloud }} --prefix _scs-"
       - name: "Run scs-compliance-check"
         run: "cd /scs-compliance && ./scs-compliance-check.py scs-compatible-${{ inputs.layer }}.yaml --version ${{ inputs.version }} -o result.yaml -s ${{ inputs.cloud }} -a os_cloud=${{ inputs.cloud }}"

--- a/.github/workflows/scs-compliance-check.yml
+++ b/.github/workflows/scs-compliance-check.yml
@@ -32,6 +32,8 @@ jobs:
               auth:
                 password: ${{ secrets[inputs.secret_name] }}
           EOF
+      - name: "Clean up any lingering resources from previous run"
+        run: "cd /scs-compliance && ./cleanup.py -c ${{ inputs.cloud }} --prefix _scs-"
       - name: "Run scs-compliance-check"
         run: "cd /scs-compliance && ./scs-compliance-check.py scs-compatible-${{ inputs.layer }}.yaml --version ${{ inputs.version }} -o result.yaml -s ${{ inputs.cloud }} -a os_cloud=${{ inputs.cloud }}"
       - name: "Upload results"


### PR DESCRIPTION
Even if we want to completely switch to Zuul, it's not clear when this happens and in the meantime there is still plenty of opportunity that this is the reason for failed tests. The fix is rather easy, I just copied and slightly adapted the invocation from `playbooks/pre_cloud.yaml`.