### PR TITLE
Housekeeping: Bump certifi to 2024.7.4

### DIFF
--- a/Tests/requirements.txt
+++ b/Tests/requirements.txt
@@ -16,7 +16,7 @@ attrs==23.2.0
     # via aiohttp
 bcrypt==4.1.3
     # via paramiko
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   kubernetes-asyncio
     #   requests

--- a/compliance-monitor/requirements.txt
+++ b/compliance-monitor/requirements.txt
@@ -17,7 +17,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 bcrypt==4.1.3
     # via -r requirements.in
-certifi==2024.6.2
+certifi==2024.7.4
     # via
     #   httpcore
     #   httpx


### PR DESCRIPTION
* Replaces #654 because it only covers the compliance monitor.
* Fixes a low severity dependabot alert (https://github.com/SovereignCloudStack/standards/security/dependabot/13 and https://github.com/SovereignCloudStack/standards/security/dependabot/12)