### PR TITLE
Perform scs-check-adr-syntax job in a pod

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -25,11 +25,16 @@
     check:
       jobs:
         - scs-check-adr-syntax
+
 - job:
     name: scs-check-adr-syntax
     parent: base
     pre-run: playbooks/pre.yaml
     run: playbooks/adr_syntax.yaml
+    nodeset: pod-fedora-40
+    vars:
+      zuul_work_dir: "{{ zuul.project.src_dir }}"
+
 - job:
     name: scs-check-gx-scs
     parent: base
@@ -40,73 +45,85 @@
       cloud: gx-scs
       secret_key: gx_scs_key
     pre-run:
-     - playbooks/pre.yaml
+     - playbooks/pre-old.yaml
      - playbooks/pre_cloud.yaml
     run: playbooks/compliance_check.yaml
+
 - job:
     name: scs-check-gx-scs-main
     parent: scs-check-gx-scs
     branches: main
+
 - job:
     name: scs-check-artcodix
     parent: scs-check-gx-scs-main
     vars:
       cloud: artcodix
       secret_key: cnds_key
+
 - job:
     name: scs-check-pco-prod4
     parent: scs-check-gx-scs-main
     vars:
       cloud: pco-prod4
       secret_key: pco_prod4_key
+
 - job:
     name: scs-check-pco-prod3
     parent: scs-check-gx-scs-main
     vars:
       cloud: pco-prod3
       secret_key: pco_prod3_key
+
 - job:
     name: scs-check-pco-prod2
     parent: scs-check-gx-scs-main
     vars:
       cloud: pco-prod2
       secret_key: pco_prod2_key
+
 - job:
     name: scs-check-pco-prod1
     parent: scs-check-gx-scs-main
     vars:
       cloud: pco-prod1
       secret_key: pco_prod1_key
+
 - job:
     name: scs-check-poc-kdo
     parent: scs-check-gx-scs-main
     vars:
       cloud: poc-kdo
       secret_key: poc_kdo_key
+
 - job:
     name: scs-check-poc-wgcloud
     parent: scs-check-gx-scs-main
     vars:
       cloud: poc-wgcloud
       secret_key: poc_wgcloud_key
+
 - job:
     name: scs-check-regio-a
     parent: scs-check-gx-scs-main
     vars:
       cloud: regio-a
       secret_key: regio_a_key
+
 - job:
     name: scs-check-syseleven-dus2
     parent: scs-check-gx-scs-main
     vars:
       cloud: syseleven-dus2
       secret_key: syseleven_dus2_key
+
 - job:
     name: scs-check-syseleven-ham1
     parent: scs-check-gx-scs-main
     vars:
       cloud: syseleven-ham1
       secret_key: syseleven_ham1_key
+
 - job:
     name: scs-check-wavestack
     parent: scs-check-gx-scs-main

--- a/playbooks/adr_syntax.yaml
+++ b/playbooks/adr_syntax.yaml
@@ -3,15 +3,19 @@
   hosts: all
   tasks:
     - name: Run ADR syntax check script
-      ansible.builtin.shell: |
-        python3 ~/Tests/chk_adrs.py ~/Standards
+      ansible.builtin.command: |
+        python3 Tests/chk_adrs.py Standards
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul_work_dir }}"
       register: result
       changed_when: true
       failed_when: result.rc != 0
 
     - name: Run test script consistency check script
-      ansible.builtin.shell: |
-        python3 ~/Tests/iaas/flavor-naming/check_yaml.py ~/Tests/iaas
+      ansible.builtin.command: |
+        python3 Tests/iaas/flavor-naming/check_yaml.py Tests/iaas
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul_work_dir }}"
       register: result
       changed_when: true
       failed_when: result.rc != 0

--- a/playbooks/pre-old.yaml
+++ b/playbooks/pre-old.yaml
@@ -1,0 +1,23 @@
+---
+- name: Copy scripts+data and install Python dependencies
+  hosts: all
+  roles:
+    - role: ensure-pip  # https://zuul-ci.org/docs/zuul-jobs/latest/python-roles.html#role-ensure-pip
+  tasks:
+    - name: Copy ADRs on the node
+      ansible.builtin.copy:
+        src: "../Standards"
+        dest: "~/"
+        mode: 0500
+      no_log: false
+
+    - name: Copy Tests on the node
+      ansible.builtin.copy:
+        src: "../Tests"
+        dest: "~/"
+        mode: 0500
+      no_log: false
+
+    - name: Install dependencies
+      ansible.builtin.pip:
+        requirements: "~/Tests/requirements.txt"

--- a/playbooks/pre.yaml
+++ b/playbooks/pre.yaml
@@ -4,20 +4,7 @@
   roles:
     - role: ensure-pip  # https://zuul-ci.org/docs/zuul-jobs/latest/python-roles.html#role-ensure-pip
   tasks:
-    - name: Copy ADRs on the node
-      ansible.builtin.copy:
-        src: "../Standards"
-        dest: "~/"
-        mode: 0500
-      no_log: false
-
-    - name: Copy Tests on the node
-      ansible.builtin.copy:
-        src: "../Tests"
-        dest: "~/"
-        mode: 0500
-      no_log: false
-
     - name: Install dependencies
       ansible.builtin.pip:
-        requirements: ~/Tests/requirements.txt
+        chdir: "{{ ansible_user_dir }}/{{ zuul_work_dir }}"
+        requirements: "Tests/requirements.txt"


### PR DESCRIPTION
In order to improve speed of the job (reduce wait time for the VM to be
prepared) we can execute it in the K8 pod.

In addition to that get rid of double data copying (what also consumes noticeable amount of time) for the job in question. This is caused by a fact that the base Zuul job takes care of pushing the repository content to the target environment in the most optimal way. Other jobs would profit from similar change independently.

Both changes together bring job duration from very varying 2-5 minutes (excluding waiting for the job to start) down to  stable 40 sec (with 0-10 seconds job start delay).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
