### PR TITLE
Bugfix: work around bug in openstacksdk > 3.1.0

### DIFF
--- a/Tests/iaas/entropy/entropy-check.py
+++ b/Tests/iaas/entropy/entropy-check.py
@@ -334,7 +334,12 @@ def create_vm(env, all_flavors, image, server_name=SERVER_NAME):
         boot_from_volume=True, terminate_volume=True, volume_size=volume_size,
     )
     logger.debug(f"Server '{server_name}' ('{server.id}') has been created")
-    return server
+    # next, do an explicit get_server because, beginning with version 3.2.0, the openstacksdk no longer
+    # sets the interface attributes such as `public_v4`
+    # I (mbuechse) consider this a bug in openstacksdk; it was introduced with
+    # https://opendev.org/openstack/openstacksdk/commit/a8adbadf0c4cdf1539019177fb1be08e04d98e82
+    # I also consider openstacksdk architecture with the Mixins etc. smelly to say the least
+    return env.conn.get_server(server.id)
 
 
 def delete_vm(conn, server_name=SERVER_NAME):

--- a/Tests/requirements.in
+++ b/Tests/requirements.in
@@ -4,5 +4,5 @@ fabric
 kubernetes_asyncio
 python-dateutil
 PyYAML
-openstacksdk < 3.2.0
+openstacksdk
 requests

--- a/Tests/requirements.txt
+++ b/Tests/requirements.txt
@@ -75,7 +75,7 @@ multidict==6.0.5
     #   yarl
 netifaces==0.11.0
     # via openstacksdk
-openstacksdk==3.1.0
+openstacksdk==3.3.0
     # via -r requirements.in
 os-service-types==1.7.0
     # via


### PR DESCRIPTION
For details on the background, see [this comment](https://github.com/SovereignCloudStack/standards/pull/693#issuecomment-2286179683).