### PR TITLE
Bugfix: reflect (formerly, temporarily) mistaken docs in iaas scope

### DIFF
--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -160,6 +160,7 @@ timeline:
       v5: draft
       v4: effective
       v3: deprecated
+      v3-orig: deprecated
   - date: 2024-07-31
     versions:
       v4: effective
@@ -217,6 +218,17 @@ versions:
     targets:
       main: mandatory
   - version: v3
+    # comment: >
+    #   This is what our documentation wrongly stated as being v3 when we introduced v4.
+    #   What was originally v3 (and what we actually continued to test) can be found as v3-orig.
+    stabilized_at: 2024-02-28
+    include:
+      - opc-v2022.11
+      - scs-0100-v3.1
+      - scs-0102-v1
+    targets:
+      main: mandatory
+  - version: v3-orig
     stabilized_at: 2023-06-15
     include:
       - opc-v2022.11


### PR DESCRIPTION
I think the docs were wrong from ca. Nov 30, 2023 through Aug 14, 2024, between the introduction of (then-draft) v4 and the changes introducing fine-grained certificate scopes.

The scs-0100-v3 always stated that v3.0 still contained the list of flavors, but we didn't explicitly state that scope v3 referred to v3.0 of that standard instead of v3.1.