### PR TITLE
Add multi-arch support for amd64 and arm64 into Dockerfile

### DIFF
--- a/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework/Dockerfile
+++ b/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework/Dockerfile
@@ -1,12 +1,19 @@
 FROM golang:1.23
 
-# Install kubectl
-# Note: Latest version may be found on:
-# https://aur.archlinux.org/packages/kubectl-bin/
-RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.21.3/bin/linux/amd64/kubectl -O /usr/bin/kubectl && \
-    chmod +x /usr/bin/kubectl && \
-    apt-get update && \
-    apt-get install -y jq
+# Use build arguments to get the correct architecture
+ARG TARGETARCH
+
+# Install kubectl based on the architecture
+#See https://github.com/kubernetes-sigs/kubespray/pull/10066
+RUN apt-get update && apt-get install -y wget jq && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        wget https://cdn.dl.k8s.io/release/v1.31.1/bin/linux/amd64/kubectl -O /usr/bin/kubectl; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        wget https://cdn.dl.k8s.io/release/v1.31.1/bin/linux/arm64/kubectl -O /usr/bin/kubectl; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH" && exit 1; \
+    fi && \
+    chmod +x /usr/bin/kubectl
 
 COPY ./scs_k8s_tests /src/scs_k8s_tests
 WORKDIR /src
@@ -19,5 +26,3 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go test -c -o custom.test ./...
 
 CMD ["bash", "-c", "go tool test2json ./custom.test -test.v"]
-
-

--- a/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework/Makefile
+++ b/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework/Makefile
@@ -57,6 +57,7 @@ dev-prerequests:
 	@docker version
 	@sonobuoy version --short
 	@go version
+	@docker buildx version
 
 
 dev-setup: kind-init


### PR DESCRIPTION
Add multi-arch support for arm64 and amd64 into the Dockerfile

I tried it on the VM I spawned at the Hetzner:
```
root@test-arm64:~# uname -m
aarch64
```

After installing all prerequisites(buildx docker plugin needs to be installed), all make commands passed.
```
root@test-arm64:~/standards/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework# make dev-setup 

[KindCluster]   testcluster

kind create cluster --name "testcluster"
Creating cluster "testcluster" ...
 ✓ Ensuring node image (kindest/node:v1.31.0) 🖼 
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-testcluster"
You can now use your cluster with:

kubectl cluster-info --context kind-testcluster

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
root@test-arm64:~/standards/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework# sudo make dev-build 

[ContainerImageName]   ghcr.io/sovereigncloudstack/standards/scsconformance:dev
[SonobuoyPluginFile]   plugin.yaml

[build]
DOCKER_BUILDKIT=1 docker build . -f "Dockerfile" -t ""ghcr.io/sovereigncloudstack/standards"/"scsconformance":dev"
[+] Building 124.1s (12/12) FINISHED                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 1.00kB                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/golang:1.23                                                                                                                                        1.3s
 => [internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                                       0.0s
 => [stage-0 1/7] FROM docker.io/library/golang:1.23@sha256:2fe82a3f3e006b4f2a316c6a21f62b66e1330ae211d039bb8d1128e12ed57bf1                                                                         15.9s
 => => resolve docker.io/library/golang:1.23@sha256:2fe82a3f3e006b4f2a316c6a21f62b66e1330ae211d039bb8d1128e12ed57bf1                                                                                  0.0s
 => => sha256:c6b19df41c8e5073a0a91d530741ff8768020b8de487b3f6902955322eab9d0e 2.32kB / 2.32kB                                                                                                        0.0s
 => => sha256:2737b855c4589a4564aba00d16fc897fa4b8489ed918ec317ff872dc988fbbfe 2.86kB / 2.86kB                                                                                                        0.0s
 => => sha256:56c9b9253ff98351db158cb6789848656b8d54f411c0037347bf2358efb18f39 49.59MB / 49.59MB                                                                                                      0.5s
 => => sha256:364d19f59f69474a80c53fc78da91f85553e16e8ba6a28063cbebf259821119e 23.59MB / 23.59MB                                                                                                      0.5s
 => => sha256:2fe82a3f3e006b4f2a316c6a21f62b66e1330ae211d039bb8d1128e12ed57bf1 9.74kB / 9.74kB                                                                                                        0.0s
 => => sha256:843b1d8321825bc8302752ae003026f13bd15c6eef2efe032f3ca1520c5bbc07 64.00MB / 64.00MB                                                                                                      1.0s
 => => sha256:a355a3cac949bed5cda9c62103ceb0f004727cedcd2a17d7c9836aea1a452fda 70.62MB / 70.62MB                                                                                                      1.5s
 => => sha256:ecb27c98d5b9e78892d876693427ae0a01e3113b36989718360a5aa9e319fd80 86.29MB / 86.29MB                                                                                                      1.5s
 => => extracting sha256:56c9b9253ff98351db158cb6789848656b8d54f411c0037347bf2358efb18f39                                                                                                             3.0s
 => => sha256:83f1399aa9166438efeea4696812a3fa3f3397ff114492577a919f9b09f3c1ea 126B / 126B                                                                                                            1.2s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                                                                              1.5s
 => => extracting sha256:364d19f59f69474a80c53fc78da91f85553e16e8ba6a28063cbebf259821119e                                                                                                             0.8s
 => => extracting sha256:843b1d8321825bc8302752ae003026f13bd15c6eef2efe032f3ca1520c5bbc07                                                                                                             2.9s
 => => extracting sha256:ecb27c98d5b9e78892d876693427ae0a01e3113b36989718360a5aa9e319fd80                                                                                                             2.9s
 => => extracting sha256:a355a3cac949bed5cda9c62103ceb0f004727cedcd2a17d7c9836aea1a452fda                                                                                                             4.8s
 => => extracting sha256:83f1399aa9166438efeea4696812a3fa3f3397ff114492577a919f9b09f3c1ea                                                                                                             0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                     0.0s
 => => transferring context: 96.73kB                                                                                                                                                                  0.0s
 => [stage-0 2/7] RUN apt-get update && apt-get install -y wget jq &&     if [ "arm64" = "amd64" ]; then         wget https://cdn.dl.k8s.io/release/v1.31.1/bin/linux/amd64/kubectl -O /usr/bin/kube  5.3s
 => [stage-0 3/7] COPY ./scs_k8s_tests /src/scs_k8s_tests                                                                                                                                             0.0s 
 => [stage-0 4/7] WORKDIR /src                                                                                                                                                                        0.0s 
 => [stage-0 5/7] COPY go.* /src/                                                                                                                                                                     0.1s 
 => [stage-0 6/7] RUN go mod download                                                                                                                                                                 7.1s 
 => [stage-0 7/7] RUN --mount=type=cache,target=/root/.cache/go-build     go test -c -o custom.test ./...                                                                                            90.3s 
 => exporting to image                                                                                                                                                                                3.9s 
 => => exporting layers                                                                                                                                                                               3.8s
 => => writing image sha256:f40e44bdef8fe971d76aa467f0ed8899e56d80d82142b997f57cbe35835476ee                                                                                                          0.0s
 => => naming to ghcr.io/sovereigncloudstack/standards/scsconformance:dev                                                                                                                             0.0s
kind load docker-image --name "testcluster" ""ghcr.io/sovereigncloudstack/standards"/"scsconformance":dev"
Image: "ghcr.io/sovereigncloudstack/standards/scsconformance:dev" with ID "sha256:f40e44bdef8fe971d76aa467f0ed8899e56d80d82142b997f57cbe35835476ee" not yet present on node "testcluster-control-plane", loading...
root@test-arm64:~/standards/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework# make dev-run 
[run-test]
sonobuoy run --plugin plugin.yaml --wait= --timeout=
INFO[0000] create request issued                         name=sonobuoy namespace= resource=namespaces
INFO[0000] create request issued                         name=sonobuoy-serviceaccount namespace=sonobuoy resource=serviceaccounts
INFO[0000] create request issued                         name=sonobuoy-serviceaccount-sonobuoy namespace= resource=clusterrolebindings
INFO[0000] create request issued                         name=sonobuoy-serviceaccount-sonobuoy namespace= resource=clusterroles
INFO[0000] create request issued                         name=sonobuoy-config-cm namespace=sonobuoy resource=configmaps
INFO[0000] create request issued                         name=sonobuoy-plugins-cm namespace=sonobuoy resource=configmaps
INFO[0000] create request issued                         name=sonobuoy namespace=sonobuoy resource=pods
INFO[0000] create request issued                         name=sonobuoy-aggregator namespace=sonobuoy resource=services
The Sonobuoy aggregator is in the 'Pending' state. This is normal as the pod is created and begins to run, but if this state persists, use kubectl to debug further.
root@test-arm64:~/standards/Tests/kaas/kaas-sonobuoy-go-example-e2e-framework# make dev-result 
[result]
#outfile= && mkdir results && tar -xf  -C results
sonobuoy retrieve
202409241331_sonobuoy_ad826392-f8e4-42f5-8566-14a67c24b8cd.tar.gz
sonobuoy results *.tar.gz
Plugin: scsconformance
Status: failed
Total: 18
Passed: 13
Failed: 5
Skipped: 0

Failed tests:
Test_scs_0200_sonobuoy_fail
Test_scs_0201_TestDummyIn
Test_scs_0201_TestListPodsFailing/pod_list/pods_from_kube-test-a
Test_scs_0201_TestListPodsFailing/pod_list
Test_scs_0201_TestListPodsFailing

Run Details:
API Server version: v1.31.0
Node health: 1/1 (100%)
Pods health: 11/11 (100%)
Errors detected in files:
Errors:
31 podlogs/kube-system/kube-scheduler-testcluster-control-plane/logs/kube-scheduler.txt
 9 podlogs/kube-system/coredns-6f6b679f8f-678zb/logs/coredns.txt
 9 podlogs/kube-system/coredns-6f6b679f8f-s52f8/logs/coredns.txt
 4 podlogs/kube-system/kube-controller-manager-testcluster-control-plane/logs/kube-controller-manager.txt
 1 podlogs/kube-system/kube-proxy-s77lq/logs/kube-proxy.txt
Warnings:
31 podlogs/kube-system/kube-apiserver-testcluster-control-plane/logs/kube-apiserver.txt
19 podlogs/kube-system/kube-scheduler-testcluster-control-plane/logs/kube-scheduler.txt
 7 podlogs/kube-system/kube-controller-manager-testcluster-control-plane/logs/kube-controller-manager.txt
 3 podlogs/kube-system/etcd-testcluster-control-plane/logs/etcd.txt
 1 podlogs/sonobuoy/sonobuoy/logs/kube-sonobuoy.txt
mkdir results
tar -xf *.tar.gz -C results
```