### PR TITLE
Fix: give CSPs 2 weeks for providing k8s patch releases

### DIFF
--- a/Standards/scs-0210-v2-k8s-version-policy.md
+++ b/Standards/scs-0210-v2-k8s-version-policy.md
@@ -56,7 +56,7 @@ In order to keep up-to-date with the latest Kubernetes features, bug fixes and s
 the provided Kubernetes versions should be kept up-to-date with new upstream releases:
 
 - The latest minor version MUST be provided no later than 4 months after release.
-- The latest patch version MUST be provided no later than 1 week after release.
+- The latest patch version MUST be provided no later than 2 weeks after release.
 - This time period MUST be even shorter for patches that fix critical CVEs.
   In this context, a critical CVE is a CVE with a CVSS base score >= 8 according
   to the CVSS version used in the original CVE record (e.g., CVSSv3.1).

--- a/Tests/kaas/k8s-version-policy/k8s_version_policy.py
+++ b/Tests/kaas/k8s-version-policy/k8s_version_policy.py
@@ -45,7 +45,7 @@ import yaml
 
 
 MINOR_VERSION_CADENCE = timedelta(days=120)
-PATCH_VERSION_CADENCE = timedelta(weeks=1)
+PATCH_VERSION_CADENCE = timedelta(weeks=2)
 CVE_VERSION_CADENCE = timedelta(days=2)
 CVE_SEVERITY = 8  # CRITICAL
 

--- a/Tests/kaas/k8s-version-policy/k8s_version_policy_test.py
+++ b/Tests/kaas/k8s-version-policy/k8s_version_policy_test.py
@@ -44,8 +44,8 @@ def release_data():
 K8S_VERSION = K8sVersion(1, 28, 5)
 EXPECTED_RECENCIES = {
     datetime(2024, 1, 17): True,
-    datetime(2024, 1, 24): True,
-    datetime(2024, 1, 25): False,
+    datetime(2024, 1, 31): True,
+    datetime(2024, 2, 1): False,
 }
 
 


### PR DESCRIPTION
as discussed in SIG Standardization/Certification [meeting of 2024-08-22](https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20240822.md#stabilize-scs-compatible-kaas-v1).