### PR TITLE
Improve robustness and reliability of the volume backup API conformance check script

### DIFF
--- a/Tests/iaas/volume-backup/volume-backup-tester.py
+++ b/Tests/iaas/volume-backup/volume-backup-tester.py
@@ -222,6 +222,10 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
                 # its own in the meantime ignore it
                 continue
             except ConformanceTestException as e:
+                # This exception happens if the backup state does not reach any
+                # of the desired ones specified above. We do not need to set
+                # cleanup_was_successful to False here since any remaining ones
+                # will be caught in the next loop down below anyway.
                 logging.warning(str(e))
             else:
                 logging.info(f"↳ deleting volume backup '{backup.id}' ...")

--- a/Tests/iaas/volume-backup/volume-backup-tester.py
+++ b/Tests/iaas/volume-backup/volume-backup-tester.py
@@ -164,10 +164,10 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
     """
 
     def wait_for_resource(resource_type: str, resource_id: str,
-                          expected_status="available") -> None:
+                          expected_status=["available"]) -> None:
         seconds_waited = 0
         get_func = getattr(conn.block_storage, f"get_{resource_type}")
-        while get_func(resource_id).status != expected_status:
+        while get_func(resource_id).status not in expected_status:
             time.sleep(1.0)
             seconds_waited += 1
             assert seconds_waited < timeout, (
@@ -184,7 +184,7 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
     for backup in backups:
         if backup.name.startswith(prefix):
             try:
-                wait_for_resource("backup", backup.id)
+                wait_for_resource("backup", backup.id, ["available", "error"])
             except openstack.exceptions.ResourceNotFound:
                 # if the resource has vanished on
                 # its own in the meantime ignore it
@@ -209,7 +209,7 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
     for volume in volumes:
         if volume.name.startswith(prefix):
             try:
-                wait_for_resource("volume", volume.id)
+                wait_for_resource("volume", volume.id, ["available", "error"])
             except openstack.exceptions.ResourceNotFound:
                 # if the resource has vanished on
                 # its own in the meantime ignore it

--- a/Tests/iaas/volume-backup/volume-backup-tester.py
+++ b/Tests/iaas/volume-backup/volume-backup-tester.py
@@ -301,8 +301,10 @@ def main():
         cleanup(conn, prefix=args.prefix, timeout=args.timeout)
     else:
         cleanup(conn, prefix=args.prefix, timeout=args.timeout)
-        test_backup(conn, prefix=args.prefix, timeout=args.timeout)
-        cleanup(conn, prefix=args.prefix, timeout=args.timeout)
+        try:
+            test_backup(conn, prefix=args.prefix, timeout=args.timeout)
+        finally:
+            cleanup(conn, prefix=args.prefix, timeout=args.timeout)
 
 
 if __name__ == "__main__":

--- a/Tests/iaas/volume-backup/volume-backup-tester.py
+++ b/Tests/iaas/volume-backup/volume-backup-tester.py
@@ -190,7 +190,7 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
     """
 
     def wait_for_resource(resource_type: str, resource_id: str,
-                          expected_status=["available"]) -> None:
+                          expected_status=("available", )) -> None:
         seconds_waited = 0
         get_func = getattr(conn.block_storage, f"get_{resource_type}")
         while get_func(resource_id).status not in expected_status:
@@ -212,7 +212,7 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
     for backup in backups:
         if backup.name.startswith(prefix):
             try:
-                wait_for_resource("backup", backup.id, ["available", "error"])
+                wait_for_resource("backup", backup.id, expected_status=("available", "error"))
             except openstack.exceptions.ResourceNotFound:
                 # if the resource has vanished on
                 # its own in the meantime ignore it
@@ -247,7 +247,7 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
     for volume in volumes:
         if volume.name.startswith(prefix):
             try:
-                wait_for_resource("volume", volume.id, ["available", "error"])
+                wait_for_resource("volume", volume.id, expected_status=("available", "error"))
             except openstack.exceptions.ResourceNotFound:
                 # if the resource has vanished on
                 # its own in the meantime ignore it

--- a/Tests/iaas/volume-backup/volume-backup-tester.py
+++ b/Tests/iaas/volume-backup/volume-backup-tester.py
@@ -332,22 +332,22 @@ def main():
         cloud,
         password=getpass.getpass("Enter password: ") if args.ask else None
     )
+
+    if not cleanup(conn, prefix=args.prefix, timeout=args.timeout):
+        raise Exception(
+            f"Cleanup was not successful, there may be leftover resources "
+            f"with the '{args.prefix}' prefix"
+        )
     if args.cleanup_only:
+        return
+    try:
+        test_backup(conn, prefix=args.prefix, timeout=args.timeout)
+    finally:
         if not cleanup(conn, prefix=args.prefix, timeout=args.timeout):
-            raise Exception(
-                f"Cleanup was not successful, there may be leftover resources "
-                f"with the '{args.prefix}' prefix"
+            logging.info(
+                f"There may be leftover resources with the "
+                f"'{args.prefix}' prefix that could not be cleaned up!"
             )
-    else:
-        cleanup(conn, prefix=args.prefix, timeout=args.timeout)
-        try:
-            test_backup(conn, prefix=args.prefix, timeout=args.timeout)
-        finally:
-            if not cleanup(conn, prefix=args.prefix, timeout=args.timeout):
-                logging.info(
-                    f"There may be leftover resources with the "
-                    f"'{args.prefix}' prefix that could not be cleaned up!"
-                )
 
 
 if __name__ == "__main__":

--- a/Tests/iaas/volume-backup/volume-backup-tester.py
+++ b/Tests/iaas/volume-backup/volume-backup-tester.py
@@ -231,16 +231,14 @@ def cleanup(conn: openstack.connection.Connection, prefix=DEFAULT_PREFIX,
     ) > 0:
         time.sleep(1.0)
         seconds_waited += 1
-        try:
-            ensure(
-                seconds_waited < timeout,
-                f"Timeout reached while waiting for all backups with prefix "
+        if seconds_waited >= timeout:
+            cleanup_was_successful = False
+            print(
+                "WARNING:"
+                "Timeout reached while waiting for all backups with prefix "
                 f"'{prefix}' to finish deletion during cleanup after "
                 f"{seconds_waited} seconds"
             )
-        except ConformanceTestException as e:
-            print("WARNING:", str(e))
-            cleanup_was_successful = False
             break
 
     volumes = conn.block_storage.volumes()


### PR DESCRIPTION
According to research in #795, Cinder will create volume backup resources even if the volume backup service is disabled/down/absent but such resources cannot be deleted by the normal user and will be stuck in error state. This made the script get stuck and not even reach the volume cleanup.

Currently it does not seem possible for a non-admin user to determine the presence and health of the volume backup service before attempting to create backups.
This PR aims to increase the reliability and robustness of the corresponding check script to handle misconfigured clouds a bit more gracefully:

- attempt to cleanup resources in error state, not only available ones
- don't use `assert` for error handling which would be omitted by `python3 -O`
- try to continue cleanups even if timeouts happen to clean up as much as possible

Closes #795