### PR TITLE
Fix: add missing legend for version suffixes

### DIFF
--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -2,6 +2,9 @@
 we could of course iterate over results etc., but hardcode the table (except the actual results, of course)
 for the time being to have the highest degree of control
 -#}
+
+Version numbers are suffixed by a symbol depending on state: * for _draft_, † for _warn_ (soon to be deprecated), and †† for _deprecated_.
+
 {% set iaas = '50393e6f-2ae1-4c5c-a62c-3b75f2abef3f' -%}
 | Name  | Description  | Operator  | [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/)  | HealthMon  |
 |-------|--------------|-----------|----------------------|:----------:|


### PR DESCRIPTION
![Screenshot from 2024-11-04 20-42-51](https://github.com/user-attachments/assets/8acabfba-37a9-4020-990b-ff1742e2fa25)

very simple first shot, just to close this gap; can be improved upon any time