### PR TITLE
Harmonize titles between main documents and supplements

### DIFF
--- a/Standards/scs-0102-v1-image-metadata.md
+++ b/Standards/scs-0102-v1-image-metadata.md
@@ -1,5 +1,5 @@
 ---
-title: SCS Image Metadata Standard
+title: SCS Image Metadata
 type: Standard
 stabilized_at: 2022-10-31
 status: Stable

--- a/Standards/scs-0118-v1-taxonomy-of-failsafe-levels.md
+++ b/Standards/scs-0118-v1-taxonomy-of-failsafe-levels.md
@@ -1,5 +1,5 @@
 ---
-title: Taxonomy of Failsafe Levels
+title: SCS Taxonomy of Failsafe Levels
 type: Decision Record
 status: Draft
 track: IaaS


### PR DESCRIPTION
This change will make the table in https://docs.scs.community/standards/standards/overview look better: if the title of the main document is a prefix of the supplement's title, then it won't be duplicated in the table.