### PR TITLE
Add k8s v1.31 to k8s-version-policy

### DIFF
--- a/Tests/kaas/k8s-version-policy/k8s-eol-data.yml
+++ b/Tests/kaas/k8s-version-policy/k8s-eol-data.yml
@@ -1,5 +1,7 @@
 # https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches
 
+- branch: '1.31'
+  end-of-life: '2025-10-28'
 - branch: '1.30'
   end-of-life: '2025-06-28'
 - branch: '1.29'


### PR DESCRIPTION
The k8s version `1.31.2` is the latest and should not see this error, resolved by updating the `k8s-eol-data.yml` file
```
python3.10 kaas/k8s-version-policy/k8s_version_policy.py --kubeconfig ~/.kube/config
WARNING: The EOL data in k8s-eol-data.yml isn't up-to-date.
INFO: Checking cluster specified by default context in /home/miso/.kube/config.
ERROR: The K8s cluster version 1.31.2 of cluster 'minikube' is already EOL.
version-policy-check: FAIL
```