### PR TITLE
Fix gen_sonobuoy_result_file

### DIFF
--- a/Tests/kaas/k8s-default-storage-class/k8s-default-storage-class-check.py
+++ b/Tests/kaas/k8s-default-storage-class/k8s-default-storage-class-check.py
@@ -25,6 +25,7 @@ import sys
 import time
 import json
 import logging
+import os
 
 from kubernetes import client
 from helper import gen_sonobuoy_result_file
@@ -259,7 +260,7 @@ def main(argv):
     if return_code == 0:
         return_message = "all tests passed"
 
-    gen_sonobuoy_result_file(return_code, return_message, __file__)
+    gen_sonobuoy_result_file(return_code, return_message, os.path.basename(__file__))
 
     return return_code
 


### PR DESCRIPTION
This PR should fix `gen_sonobuoy_result_file`, when I run the `SCS KaaS default storage class v2` test l got this error:

```bash
miso@PC-Miso:~/standards/Tests/kaas$ python3 k8s-default-storage-class/k8s-default-storage-class-check.py

Traceback (most recent call last):
  File "/home/ubuntu/standards/Tests/kaas/k8s-default-storage-class/k8s-default-storage-class-check.py", line 269, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/home/ubuntu/standards/Tests/kaas/k8s-default-storage-class/k8s-default-storage-class-check.py", line 263, in main
    gen_sonobuoy_result_file(return_code, return_message, __file__)
  File "/home/ubuntu/standards/Tests/kaas/k8s-default-storage-class/helper.py", line 73, in gen_sonobuoy_result_file
    with open(f"./{test_name}.result.yaml", "w") as file:
FileNotFoundError: [Errno 2] No such file or directory: './/home/ubuntu/standards/Tests/kaas/k8s-default-storage-class/k8s-default-storage-class-check.result.yaml'
```