### PR TITLE
allow versions which provide build info to be versionchecked

### DIFF
--- a/Tests/kaas/k8s-version-policy/k8s_version_policy.py
+++ b/Tests/kaas/k8s-version-policy/k8s_version_policy.py
@@ -171,7 +171,7 @@ K8sVersion.MINIMUM = K8sVersion(0, 0)
 
 
 def parse_version(version_str: str) -> K8sVersion:
-    cleansed = version_str.strip().removeprefix("v")
+    cleansed = version_str.strip().removeprefix("v").split("+")[0]
     try:
         major, minor, patch = cleansed.split(".")
         return K8sVersion(int(major), int(minor), int(patch))

--- a/Tests/kaas/k8s-version-policy/k8s_version_policy.py
+++ b/Tests/kaas/k8s-version-policy/k8s_version_policy.py
@@ -171,7 +171,7 @@ K8sVersion.MINIMUM = K8sVersion(0, 0)
 
 
 def parse_version(version_str: str) -> K8sVersion:
-    cleansed = version_str.strip().removeprefix("v").split("+")[0]
+    cleansed = version_str.strip().removeprefix("v").split("+")[0]  # remove leading v as well as build info
     try:
         major, minor, patch = cleansed.split(".")
         return K8sVersion(int(major), int(minor), int(patch))


### PR DESCRIPTION
Some Distributions provide buildinfo as extension to the semver

```
<valid semver> ::= <version core>
                 | <version core> "-" <pre-release>
                 | <version core> "+" <build>
                 | <version core> "-" <pre-release> "+" <build>
```

this might result in version strings like `Kubernetes Version: v1.29.8+f10c92d`

currently, the version_check fails with "Unrecognized version format:"

This small change allows Kubernetes Distributions which provide the buildinfo to be versionchecked. 