### PR TITLE
Draft: Feat/node distribution implementation notes

### DIFF
--- a/Standards/scs-0214-w1-k8s-node-distribution-implementation-testing.md
+++ b/Standards/scs-0214-w1-k8s-node-distribution-implementation-testing.md
@@ -28,10 +28,10 @@ In order to achieve compliance, the `topology.scs.community/host-id` tag has to 
 kubectl label nodes <node-name> "topology.scs.community/host-id"=<hostID>
 ```
 
-The steps necessary to get hostID of a virtual or baremetal machine running a node can be different for each CSP, but using `openstack` as an example:
+The steps necessary to get hostID of a virtual or baremetal machine running a node can be different for each CSP. For example, using `openstack`, we can list machine names (which should correspond to node names) with their respective hostIDs using the following command:
 
 ```
-openstack server list -f json | jq -r '.[].ID'
+openstack server list -f json | jq -r '.[].ID' | while read id; do openstack server show $id -f json; done | jq '{ (.name): .hostId }'
 ```
 
 ## Automated tests

--- a/Standards/scs-0214-w1-k8s-node-distribution-implementation-testing.md
+++ b/Standards/scs-0214-w1-k8s-node-distribution-implementation-testing.md
@@ -22,6 +22,18 @@ Node distribution metadata is provided through the usage of the labels
 At the moment, not all labels are set automatically by most K8s cluster utilities, which incurs
 additional setup and maintenance costs.
 
+In order to achieve compliance, the `topology.scs.community/host-id` tag has to be set manually for now. It should be done after the cluster deployment, when all nodes are ready and IDs of host machines are accessible by the user. The nodes can be labeled using the following command:
+
+```
+kubectl label nodes <node-name> "topology.scs.community/host-id"=<hostID>
+```
+
+The steps necessary to get hostID of a virtual or baremetal machine running a node can be different for each CSP, but using `openstack` as an example:
+
+```
+openstack server list -f json | jq -r '.[].ID'
+```
+
 ## Automated tests
 
 ### Notes


### PR DESCRIPTION
A lot of time was spent trying to spawn a working cluster in the gx-scs, with the correct configuration and labelling, which in the end wasn't properly achieved due to some issues with loadbalancers, which we weren't able to resolve. There have been many changes and discussions about the [standard](https://github.com/SovereignCloudStack/standards/issues/639) during the work on the task. Once the standard is stabilised, further discussion will probably be necessary and the implementation could also be properly finalized. For now, it should be easy to manually add the `hostID` label to the nodes based on their underlying bare metal or virtual machine.