### PR TITLE
fix: Test id not machting sonobuoy 'check_name'

### DIFF
--- a/Tests/scs-compatible-kaas.yaml
+++ b/Tests/scs-compatible-kaas.yaml
@@ -39,7 +39,7 @@ modules:
     url: https://docs.scs.community/standards/scs-0219-v1-kaas-networking
     run:
       - executable: ./kaas/sonobuoy_handler/run_sonobuoy.py
-        args: -k {subject_root}/kubeconfig.yaml -r {subject_root}/sono-results -c 'kaas-networking-check' -a '--e2e-focus "NetworkPolicy"'
+        args: -k {subject_root}/kubeconfig.yaml -r {subject_root}/sono-results -c 'scs-0219-v1' -a '--e2e-focus "NetworkPolicy"'
     testcases:
       - id: kaas-networking-check
         tags: [mandatory]


### PR DESCRIPTION
In the `scs-compatible-kaas.yaml`, the ID of the test case must match the `check_name` that is passed to the `sonobuoy_handler.py` to execute the test.
Otherwise the test will be listed as `MISSING` in the final report. 