### PR TITLE
Add janiskemper as nominee for project board

### DIFF
--- a/Community-Governance/2024-12-project-board-nominees.md
+++ b/Community-Governance/2024-12-project-board-nominees.md
@@ -8,3 +8,4 @@ For the term 2024-12 - 2025-12 the following people are nominated / have nominat
 | Kurt Garloff      | @garloff      | <scs@garloff.de>                    |
 | Matthias Büchse   | @mbuechse     | <matthias.buechse@cloudandheat.com> |
 | Michael Bayr      | @michaelbayr  | <mb@artcodix.com>                   |
+| Janis Kemper      | @janiskemper  | <janis.kemper@syself.com>           |


### PR DESCRIPTION
Add myself, Janis Kemper, as nominee for the SCS Project board.