### PR TITLE
Hotfix: exclude cc-rrze from nightly Zuul test because ...

### DIFF
--- a/Tests/config.toml
+++ b/Tests/config.toml
@@ -19,7 +19,7 @@ scopes = [
 subjects = [
     "gx-scs",
     "artcodix",
-    "cc-rrze",
+    # currently not reachable from outside: "cc-rrze",
     "pco-prod1",
     "pco-prod2",
     "pco-prod3",


### PR DESCRIPTION
it is not reachable from outside and triggers 'lethal' timeouts