### PR TITLE
Only use EC2 creds from our project. Clean up after use.

### DIFF
--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -143,7 +143,7 @@ def s3_from_ostack(creds, conn, endpoint):
     if found_ec2:
         creds["AK"] = found_ec2["access"]
         creds["SK"] = found_ec2["secret"]
-        return None
+        return
     # Generate keyid and secret
     ak = uuid.uuid4().hex
     sk = uuid.uuid4().hex
@@ -152,13 +152,12 @@ def s3_from_ostack(creds, conn, endpoint):
         crd = conn.identity.create_credential(type="ec2", blob=blob,
                                               user_id=conn.current_user_id,
                                               project_id=conn.current_project_id)
-        creds["AK"] = ak
-        creds["SK"] = sk
-        return crd.id
-    except BaseException as excn:
-        logger.warning(f"ec2 creds creation failed: {excn!s}")
-        # pass
-    return None
+    except BaseException:
+        logger.warning(f"ec2 creds creation failed", exc_info=True)
+        return
+    creds["AK"] = ak
+    creds["SK"] = sk
+    return crd.id
 
 
 def check_for_s3_and_swift(conn: openstack.connection.Connection, s3_credentials=None):

--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -8,13 +8,13 @@ As the s3 endpoint might differ, a missing one will only result in a warning.
 """
 
 import argparse
-import boto3
 from collections import Counter
 import logging
 import os
 import re
 import sys
 import uuid
+import boto3
 
 import openstack
 
@@ -143,9 +143,10 @@ def s3_from_ostack(creds, conn, endpoint):
         creds["AK"] = ak
         creds["SK"] = sk
         return crd.id
-    except BaseException as exc:
-        print(f"WARNING: ec2 creds creation failed: {exc!s}", file=sys.stderr)
+    except BaseException as excn:
+        print(f"WARNING: ec2 creds creation failed: {excn!s}", file=sys.stderr)
         # pass
+    return None
 
 
 def check_for_s3_and_swift(conn: openstack.connection.Connection, s3_credentials=None):

--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -20,6 +20,7 @@ import openstack
 
 
 TESTCONTNAME = "scs-test-container"
+EC2MARKER = "TmpMandSvcTest"
 
 logger = logging.getLogger(__name__)
 mandatory_services = ["compute", "identity", "image", "network",
@@ -125,15 +126,19 @@ def s3_from_ostack(creds, conn, endpoint):
     project_id = conn.identity.get_project_id()
     ec2_creds = [cred for cred in conn.identity.credentials()
                  if cred.type == "ec2" and cred.project_id == project_id]
-    if len(ec2_creds):
+    for cred in ec2_creds:
         # FIXME: Assume cloud is not evil
-        ec2_dict = eval(ec2_creds[0].blob, {"null": None})
+        ec2_dict = eval(cred.blob, {"null": None})
         creds["AK"] = ec2_dict["access"]
         creds["SK"] = ec2_dict["secret"]
+        # Clean up old EC2 creds and jump over
+        if creds["SK"][-len(EC2MARKER):] == EC2MARKER:
+            conn.identity.delete_credential(cred)
+            continue
         return None
     # Generate keyid and secret
     ak = uuid.uuid4().hex
-    sk = uuid.uuid4().hex
+    sk = uuid.uuid4().hex + EC2MARKER
     blob = f'{{"access": "{ak}", "secret": "{sk}"}}'
     try:
         crd = conn.identity.create_credential(type="ec2", blob=blob,

--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -9,6 +9,7 @@ As the s3 endpoint might differ, a missing one will only result in a warning.
 
 import argparse
 from collections import Counter
+import json
 import logging
 import os
 import re
@@ -127,8 +128,11 @@ def s3_from_ostack(creds, conn, endpoint):
     ec2_creds = [cred for cred in conn.identity.credentials()
                  if cred.type == "ec2" and cred.project_id == project_id]
     for cred in ec2_creds:
-        # FIXME: Assume cloud is not evil
-        ec2_dict = eval(cred.blob, {"null": None})
+        try:
+            ec2_dict = json.loads(cred.blob)
+        except Exception:
+            logger.warning(f"unable to parse credential {cred!r}", exc_info=True)
+            continue
         # print(f"DEBUG: Cred: {ec2_dict}")
         creds["AK"] = ec2_dict["access"]
         creds["SK"] = ec2_dict["secret"]

--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -14,8 +14,8 @@ import os
 import re
 import sys
 import uuid
-import boto3
 
+import boto3
 import openstack
 
 

--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -136,7 +136,7 @@ def s3_from_ostack(creds, conn, endpoint):
             continue
         # Clean up old EC2 creds and jump over
         if ec2_dict.get("owner") == EC2MARKER:
-            logger.debug(f"Removing leftover credential {ec2_dict['access']}}")
+            logger.debug(f"Removing leftover credential {ec2_dict['access']}")
             conn.identity.delete_credential(cred)
             continue
         found_ec2 = ec2_dict
@@ -153,7 +153,7 @@ def s3_from_ostack(creds, conn, endpoint):
                                               user_id=conn.current_user_id,
                                               project_id=conn.current_project_id)
     except BaseException:
-        logger.warning(f"ec2 creds creation failed", exc_info=True)
+        logger.warning("ec2 creds creation failed", exc_info=True)
         return
     creds["AK"] = ak
     creds["SK"] = sk

--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -13,16 +13,13 @@ import logging
 import os
 import re
 import sys
-import signal
 import uuid
 import boto3
 
 import openstack
 
-# Globals
+
 TESTCONTNAME = "scs-test-container"
-EC2CRED = None
-OSCONN = None
 
 logger = logging.getLogger(__name__)
 mandatory_services = ["compute", "identity", "image", "network",
@@ -31,10 +28,8 @@ block_storage_service = ["volume", "volumev3", "block-storage"]
 
 
 def check_presence_of_mandatory_services(conn: openstack.connection.Connection, s3_credentials=None):
-    "Go over list of mandatory services and ensure they are all in the catalog"
     services = conn.service_catalog
 
-    # We don't require swift if S3 can be found otherwise
     if s3_credentials:
         mandatory_services.remove("object-store")
     for svc in services:
@@ -118,36 +113,10 @@ def s3_from_env(creds, fieldnm, env, prefix=""):
         logger.warning(f"s3_creds[{fieldnm}] not set")
 
 
-def cleanup_ec2_cred(conn):
-    "Remove ec2_cred if created"
-    if conn and EC2CRED:
-        conn.identity.delete_credential(EC2CRED)
-
-
-def breakhandler(sig, frame):
-    "Clean up created ec2 credential is any and reraise signal"
-    # global OSCONN
-    # print(f"Handle signal {signal.strsignal(sig)}: Conn {os_conn}, clean cred {ec2_cred}", file=sys.stderr)
-    cleanup_ec2_cred(OSCONN)
-    signal.signal(sig, signal.SIG_DFL)
-    signal.raise_signal(sig)
-
-
-def install_sighandler(conn):
-    "Set OpenStack connection and install signal handler"
-    global OSCONN
-    OSCONN = conn
-    signal.signal(signal.SIGINT, breakhandler)
-    signal.signal(signal.SIGTERM, breakhandler)
-    signal.signal(signal.SIGHUP, breakhandler)
-    signal.signal(signal.SIGPIPE, breakhandler)
-
-
 def s3_from_ostack(creds, conn, endpoint):
-    """Fill in creds from openstack swift/keystone
-       Sets global ec2_cred *if* an ec2 credential was created,
-    """
-    global EC2CRED
+    """Set creds from openstack swift/keystone
+       Returns credential ID *if* an ec2 credential was created,
+       None otherwise."""
     rgx = re.compile(r"^(https*://[^/]*)/")
     match = rgx.match(endpoint)
     if match:
@@ -161,27 +130,25 @@ def s3_from_ostack(creds, conn, endpoint):
         ec2_dict = eval(ec2_creds[0].blob, {"null": None})
         creds["AK"] = ec2_dict["access"]
         creds["SK"] = ec2_dict["secret"]
-        return
+        return None
     # Generate keyid and secret
     ak = uuid.uuid4().hex
     sk = uuid.uuid4().hex
     blob = f'{{"access": "{ak}", "secret": "{sk}"}}'
     try:
-        install_sighandler(conn)
         crd = conn.identity.create_credential(type="ec2", blob=blob,
                                               user_id=conn.current_user_id,
                                               project_id=conn.current_project_id)
         creds["AK"] = ak
         creds["SK"] = sk
-        EC2CRED = crd.id
+        return crd.id
     except BaseException as excn:
         logger.warning(f"ec2 creds creation failed: {excn!s}")
         # pass
-    return
+    return None
 
 
 def check_for_s3_and_swift(conn: openstack.connection.Connection, s3_credentials=None):
-    "Check S3 presence; either from S3_ env or swift."
     # If we get credentials, we assume that there is no Swift and only test s3
     if s3_credentials:
         try:
@@ -209,7 +176,7 @@ def check_for_s3_and_swift(conn: openstack.connection.Connection, s3_credentials
         )
         return 1
     # Get S3 endpoint (swift) and ec2 creds from OpenStack (keystone)
-    s3_from_ostack(s3_creds, conn, endpoint)
+    ec2_cred = s3_from_ostack(s3_creds, conn, endpoint)
     # Overrides (var names are from libs3, in case you wonder)
     s3_from_env(s3_creds, "HOST", "S3_HOSTNAME", "https://")
     s3_from_env(s3_creds, "AK", "S3_ACCESS_KEY_ID")
@@ -244,12 +211,12 @@ def check_for_s3_and_swift(conn: openstack.connection.Connection, s3_credentials
     if s3_buckets == [TESTCONTNAME]:
         del_bucket(s3, TESTCONTNAME)
     # Clean up ec2 cred IF we created one
-    cleanup_ec2_cred(conn)
+    if ec2_cred:
+        conn.identity.delete_credential(ec2_cred)
     return result
 
 
 def main():
-    "Main function"
     parser = argparse.ArgumentParser(
         description="SCS Mandatory IaaS Service Checker")
     parser.add_argument(

--- a/Tests/iaas/mandatory-services/mandatory-iaas-services.py
+++ b/Tests/iaas/mandatory-services/mandatory-iaas-services.py
@@ -203,9 +203,6 @@ def check_for_s3_and_swift(conn: openstack.connection.Connection, s3_credentials
         result = 1
     else:
         logger.info("SUCCESS: S3 and Swift exist and agree")
-    # Clean up ec2 cred IF we created one
-    if ec2_cred:
-        conn.identity.delete_credential(ec2_cred)
     # No need to clean up swift container, as we did not create one
     # (If swift and S3 agree, there will be a S3 bucket that we clean up with S3.)
     # if swift_containers == [TESTCONTNAME]:
@@ -213,6 +210,9 @@ def check_for_s3_and_swift(conn: openstack.connection.Connection, s3_credentials
     # Cleanup created S3 bucket
     if s3_buckets == [TESTCONTNAME]:
         del_bucket(s3, TESTCONTNAME)
+    # Clean up ec2 cred IF we created one
+    if ec2_cred:
+        conn.identity.delete_credential(ec2_cred)
     return result
 
 


### PR DESCRIPTION
When looking for existing EC2 credentials, we only accept those created for our own project.
If we need to create one, remember this and clean it up again.