### PR TITLE
Docusaurus does not seem to like <links> in ref lists.

### DIFF
--- a/Standards/scs-0126-v1-provider-networks.md
+++ b/Standards/scs-0126-v1-provider-networks.md
@@ -244,9 +244,9 @@ The necessary policy change is described in the implementation notes to this sta
 
 ## References
 
-[^bgp]: <https://docs.openstack.org/neutron/2024.1/admin/config-bgp-dynamic-routing.html>
-[^ovn-bgp]: <https://docs.openstack.org/ovn-bgp-agent/2024.1/readme.html>
-[^pd]: <https://docs.openstack.org/neutron/2024.1/admin/config-ipv6.html#prefix-delegation>
-[^pf]: <https://docs.openstack.org/api-ref/network/v2/index.html#floating-ips-port-forwarding>
-[^ds]: <https://docs.openstack.org/neutron/2024.1/admin/config-ipv6.html>
-[^aa]: <https://docs.openstack.org/neutron/2024.1/admin/config-auto-allocation.html>
+[^bgp]: [Neutron BGP](https://docs.openstack.org/neutron/2024.1/admin/config-bgp-dynamic-routing.html)
+[^ovn-bgp]: [Neutron BGP Agent](https://docs.openstack.org/ovn-bgp-agent/2024.1/readme.html)
+[^pd]: [Prefix delegation](https://docs.openstack.org/neutron/2024.1/admin/config-ipv6.html#prefix-delegation)
+[^pf]: [Port forwarding](https://docs.openstack.org/api-ref/network/v2/index.html#floating-ips-port-forwarding)
+[^ds]: [Dual Stack](https://docs.openstack.org/neutron/2024.1/admin/config-ipv6.html)
+[^aa]: [Auto Allocation](https://docs.openstack.org/neutron/2024.1/admin/config-auto-allocation.html)

--- a/Standards/scs-0126-w1-provider-networks-implementation.md
+++ b/Standards/scs-0126-w1-provider-networks-implementation.md
@@ -17,4 +17,4 @@ The Provider Network Standard states that CSPs SHOULD restrict this functionalit
 "create_rbac_policy": "rule:admin_only"
 ```
 
-[^rbac]: <https://docs.openstack.org/neutron/2024.1/admin/config-rbac.html#preventing-regular-users-from-sharing-objects-with-each-other>
+[^rbac]: [RBAC](https://docs.openstack.org/neutron/2024.1/admin/config-rbac.html#preventing-regular-users-from-sharing-objects-with-each-other)


### PR DESCRIPTION
github renders these well, but docusaurus breaks the build.

This breaks the docs page build, see https://github.com/SovereignCloudStack/docs/issues/307.

Patch replaces the links by classic `[Word](link)` style. There may be better workarounds, but we need the docs page building now to get R8 release notes published.