### PR TITLE
Bugfix: install sonobuoy executable in playbook

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -35,6 +35,8 @@
       kaas: false
       do_provision: false
       do_cleanup: true
+      sonobuoy_tar_gz_url: >
+        https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.57.3/sonobuoy_0.57.3_linux_amd64.tar.gz
     pre-run:
      - playbooks/pre.yaml
      - playbooks/pre_cloud.yaml

--- a/Tests/kaas/sonobuoy_handler/sonobuoy_handler.py
+++ b/Tests/kaas/sonobuoy_handler/sonobuoy_handler.py
@@ -2,6 +2,7 @@ from collections import Counter
 import json
 import logging
 import os
+import os.path
 import shlex
 import shutil
 import subprocess
@@ -9,6 +10,16 @@ import subprocess
 from junitparser import JUnitXml
 
 logger = logging.getLogger(__name__)
+
+
+def _find_sonobuoy():
+    """find sonobuoy in PATH, but also in a fixed location at ~/.local/bin to simplify use with Ansible"""
+    result = shutil.which('sonobuoy')
+    if result:
+        return result
+    result = os.path.join(os.path.expanduser('~'), '.local', 'bin', 'sonobuoy')
+    if os.path.exists(result):
+        return result
 
 
 class SonobuoyHandler:
@@ -34,7 +45,7 @@ class SonobuoyHandler:
         self.kubeconfig_path = kubeconfig
         self.working_directory = os.getcwd()
         self.result_dir_name = result_dir_name
-        self.sonobuoy = shutil.which('sonobuoy')
+        self.sonobuoy = _find_sonobuoy()
         logger.debug(f"working from {self.working_directory}")
         logger.debug(f"placing results at {self.result_dir_name}")
         logger.debug(f"sonobuoy executable at {self.sonobuoy}")

--- a/playbooks/pre_cloud.yaml
+++ b/playbooks/pre_cloud.yaml
@@ -19,7 +19,7 @@
 
     - name: Create local binary dir
       ansible.builtin.file:
-        path: "~/.local/bin"
+        path: "{{ ansible_user_dir}}/.local/bin"
         state: directory
         recurse: true
 
@@ -27,7 +27,7 @@
       ansible.builtin.shell:
         curl -L {{ sonobuoy_tar_gz_url | trim | quote }} | tar xz sonobuoy
       args:
-        chdir: "~/.local/bin/"
+        chdir: "{{ ansible_user_dir}}/.local/bin/"
         creates: sonobuoy
       when: kaas | bool
 

--- a/playbooks/pre_cloud.yaml
+++ b/playbooks/pre_cloud.yaml
@@ -25,7 +25,7 @@
 
     - name: Install Sonobuoy
       ansible.builtin.shell:
-        curl -L {{ sonobuoy_tar_gz_url | quote }} | tar xz sonobuoy
+        curl -L {{ sonobuoy_tar_gz_url | trim | quote }} | tar xz sonobuoy
       args:
         chdir: "~/.local/bin/"
         creates: sonobuoy

--- a/playbooks/pre_cloud.yaml
+++ b/playbooks/pre_cloud.yaml
@@ -25,7 +25,7 @@
 
     - name: Install Sonobuoy
       ansible.builtin.shell:
-        curl -L https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.57.3/sonobuoy_0.57.3_linux_amd64.tar.gz | tar xz sonobuoy
+        curl -L {{ sonobuoy_tar_gz_url | quote }} | tar xz sonobuoy
       args:
         chdir: "~/.local/bin/"
         creates: sonobuoy

--- a/playbooks/pre_cloud.yaml
+++ b/playbooks/pre_cloud.yaml
@@ -33,7 +33,7 @@
 
     - name: Create cloud config dir
       ansible.builtin.file:
-        path: "~/.config/openstack"
+        path: "{{ ansible_user_dir }}/.config/openstack"
         state: directory
         recurse: true
         mode: "0700"
@@ -41,19 +41,19 @@
     - name: Create cloud config file
       ansible.builtin.template:
         src: "clouds.yaml.j2"
-        dest: "~/.config/openstack/clouds.yaml"
+        dest: "{{ ansible_user_dir }}/.config/openstack/clouds.yaml"
         mode: "0600"
       no_log: true
 
     - name: Create cluster config dir
       ansible.builtin.copy:
         src: ".config"
-        dest: "~/"
+        dest: "{{ ansible_user_dir }}/"
 
     - name: Create cluster config file
       ansible.builtin.template:
         src: "clusters.yaml.j2"
-        dest: "~/.config/scs/clusters.yaml"
+        dest: "{{ ansible_user_dir }}/.config/scs/clusters.yaml"
         mode: "0600"
       no_log: true
 

--- a/playbooks/pre_cloud.yaml
+++ b/playbooks/pre_cloud.yaml
@@ -17,6 +17,20 @@
         requirements: "Tests/kaas/requirements.txt"
       when: kaas | bool
 
+    - name: Create local binary dir
+      ansible.builtin.file:
+        path: "~/.local/bin"
+        state: directory
+        recurse: true
+
+    - name: Install Sonobuoy
+      ansible.builtin.shell:
+        curl -L https://github.com/vmware-tanzu/sonobuoy/releases/download/v0.57.3/sonobuoy_0.57.3_linux_amd64.tar.gz | tar xz sonobuoy
+      args:
+        chdir: "~/.local/bin/"
+        creates: sonobuoy
+      when: kaas | bool
+
     - name: Create cloud config dir
       ansible.builtin.file:
         path: "~/.config/openstack"


### PR DESCRIPTION
Questions:

- Can we assume that `.local/bin` is on PATH? Otherwise, it would have to be added.
- Do you have a better idea?

Note that this method is what is officially suggested. I have found Ansible roles for installing Sonobuoy that use some obscure Debian repository, but most such roles were actually no longer available.