### PR TITLE
Bugfix: increase KaaS timeout yet again

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -62,7 +62,7 @@
     # timeout:
     # a) these tests take a lot of time, I'm afraid, particularly Sonobuoy
     # b) keep in mind that this job covers ALL test subjects (at most 4 in parallel)
-    timeout: 9000
+    timeout: 18000  # 5 hrs -- 2.5 hrs was not enough
     vars:
       preset: kaas
       iaas: false


### PR DESCRIPTION
maybe we should increase the result lifetime of the Sonobuoy e2e test and run it less often