### PR TITLE
Pin postgres:16 version, as major upgrades need intervention.

### DIFF
--- a/compliance-monitor/docker-compose.yml
+++ b/compliance-monitor/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     restart: always
 
   postgres:
-    image: postgres
+    image: postgres:16
     volumes:
       - $HOME/data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
We should be able to regularly do a docker image pull to get the latest versions. postgres[:latest] however would be dangerous, as postgres typically requires a few manual steps when upgrading between major versions. So let's pin the major version 16 for now and change this to 17 (or something even higher_ once we have done the manual migration.