### PR TITLE
relax certification revocation regulations

### DIFF
--- a/Standards/scs-0004-v1-achieving-certification.md
+++ b/Standards/scs-0004-v1-achieving-certification.md
@@ -22,17 +22,17 @@ As operator, I want to obtain a certificate with the scope SCS-compatible IaaS o
 
 1. Each certificate issued pertains to a given combination of subject (i.e., cloud environment), scope (such as _SCS-compatible IaaS_), and version of that scope. The certificate is only valid for that combination and for the time frame that ends when the scope expires, or for six months if the expiration date for the scope is not yet fixed.
 
-2. The operator MUST ensure that the official [SCS compliance test suite](https://github.com/SovereignCloudStack/standards/tree/main/Tests) (which does not require admin privileges) is run at regular intervals and the resulting reports transmitted to the [SCS compliance monitor](https://github.com/SovereignCloudStack/standards/tree/main/compliance-monitor).
+2. The operator MUST ensure that the official [SCS compliance test suite](https://github.com/SovereignCloudStack/standards/tree/main/Tests) (which does not require admin privileges) is run at regular intervals and that all tests pass. The operator MUST submit the resulting reports to the [SCS compliance monitor](https://github.com/SovereignCloudStack/standards/tree/main/compliance-monitor).
 
    For public clouds, the SCS certification assessment body can take on this task provided that suitable access to test subject is supplied.
 
    The test suite is partitioned according to resource usage; the required test intervals depend on this classification:
 
-    - _light_: at least nightly,
+    - _light_: at least daily,
     - _medium_: at least weekly,
     - _heavy_: at least monthly.
 
-3. If the desired certificate requires manual checks, then the operator MUST offer the SCS project suitable documentation. Manual checks MUST be repeated once every quarter. In addition, the SCS certification assessment body reserves the right to occasionally verify documentation on premises.
+3. If the desired certificate requires manual checks, then the operator MUST offer suitable documentation to the SCS certification assessment body. The operator MUST ensure that these checks are repeated once every quarter. In addition, the SCS certification assessment body reserves the right to occasionally verify documentation on premises.
 
 4. Details on the standards achieved, as well as the current state and the history of all test and check results of the past 18 months will be displayed on a public webpage (henceforth, _certificate status page_) owned by SCS.
 
@@ -44,7 +44,7 @@ As operator, I want to obtain a certificate with the scope SCS-compatible IaaS o
 
 7. If the certificate is to be revoked for any reason, it will be included in a publicly available Certificate Revocation List (CRL), maintained by the SCS certification assessment body. This fact will also be reflected in the certificate status page.
 
-8. If any of the automated tests or manual checks fail after the certificate has been issued, the certificate is not immediately revoked. Rather, the automated tests MUST pass 99.x % of the runs, and the operator SHALL be notified at the second failed attempt in a row at the latest. In case a manual check fails, it has to be repeated at a date to be negotiated with the SCS certification assessment body. It MAY NOT fail more than two times in a row.
+8. If any of the automated tests or manual checks fail after the certificate has been issued, the certificate is not immediately revoked. Rather, the operator SHALL be notified automatically. The operator MUST then fix the issue and ensure that the automated tests run successfully again as quickly as possible. In case a manual check fails, it has to be repeated at a date to be negotiated with the SCS certification assessment body.
 
 ## Design Considerations
 

--- a/Standards/scs-0004-w1-achieving-certification-implementation.md
+++ b/Standards/scs-0004-w1-achieving-certification-implementation.md
@@ -20,12 +20,12 @@ that lets their applications run in a reliable way.
 The SCS certification process typically consists of a few simple steps:
 
 1. Running the SCS compliance test suite and adjusting the infrastructure until it passes.
-2. Any additional declarations (for non-testable aspects) are written and passed to the SCS certification body.
+2. Any additional declarations (for non-testable aspects) are written and passed to the SCS certification assessment body.
 3. The operator must be a member ("shaper" or "advisor" level) of the Forum SCS-Standards in the
    OSB Alliance (a non-profit) and pay the respective membership fees. Alternatively fees can
    be paid without becoming a member.
 4. The cloud can be listed on the SCS pages as *SCS-compatible* with a compatibility status that is
-   updated on a daily basis. SCS then tests the infrastructure on a daily basis.
+   updated regularly. The infrastructure is then tested on a regular basis.
 
 The precise rules that govern how certificates are issued or withdrawn are defined in the
 [SCS standard 0004](scs-0004-v1-achieving-certification.md).
@@ -59,8 +59,8 @@ criteria. In case of doubt, audits can be performed.
 The SCS brand belongs to the Open Source Business Alliance e.V. (OSBA), an non-profit organization and
 association for the Open Source Industry in Germany. After the completion of the funded SCS project
 in the OSBA on 2024-12-31, the OSBA sets up the Forum SCS-Standards
-which performs the work to evolve the SCS standards, develops the tests and perform the certification
-process and thus becomes the SCS certification body.
+which performs the work to evolve the SCS standards, develops the tests and performs the certification
+process and thus becomes the SCS certification assessment body.
 
 Members of the OSBA can become also member of the Forum SCS-Standards for an additional membership
 fee, providing the financial resources for the Forum SCS-Standards to do its work. Membership in the
@@ -75,7 +75,7 @@ can become officially certified.
 
 The SCS team will add the cloud to the [list of certified clouds](https://docs.scs.community/standards/certification/overview)
 on the SCS docs page. This can be used to prove to customers that the cloud is SCS compliant.
-Note that for public clouds, there will be a nightly job that tests the cloud for compliance, which will be
+Note that for public clouds, there will be a regular job that tests the cloud for compliance, which will be
 triggered by SCS infrastructure (zuul). For this, access to a tenant on the cloud needs
 to be provided free of charge. (This only requires very low quota, one VM is created for a minute
 in one of the tests.)
@@ -106,7 +106,7 @@ Once your cloud is listed in the
 [list of certified clouds](https://docs.scs.community/standards/certification/overview)
 which is fed by the
 [compliance manager](https://compliance.sovereignit.cloud/page/table), it
-will enjoy the nightly tests. These might fail for a number of reasons:
+will enjoy the regular tests. These might fail for a number of reasons:
 
 * There is a new version of the SCS standards in effect and you need to adjust things.
 * Your cloud was unreachable or otherwise had intermittent issues.
@@ -128,6 +128,6 @@ as it may be easier to focus on just the one failing aspect of your infrastructu
 
 Your cloud will show up as failing in the compliance manager after tests start
 failing; this is not the same as a revoked certification, though. For clouds that have been
-compliant before, it is highly recommended to work with the SCS certification body
+compliant before, it is highly recommended to work with the SCS certification assessment body
 upon such failures to determine a way back into compliance that avoids certification
 revocation.


### PR DESCRIPTION
Revision of the scs-0004 standard based on discussions in the SIG Standardization/Certification:

- https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20250626.md#certification-revocation-if-testschecks-fail
- https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20250710.md#finalize-discussions-on-scs-0004-certification-revocation

This PR attempts to implement this as follows:

- Relaxes the regulations regarding test suite reliability and frequency as they are currently not part of the `SCS-compatible` certification. It will be part of an `SCS-sovereign` certification in the future.
- Changes wording "nightly" to "daily" because it is not night everywhere at the same time.
- Make it clearer that the operator is responsible for successfully passing tests and checks.
- The supplement has been revised so that only “regularly” is used instead of specific time periods (which are defined by the standard). That way the supplement remains up to date even if the timings are adjusted in the standard.