### PR TITLE
Remove Status field from Supplement docs

### DIFF
--- a/Standards/scs-0001-v1-sovereign-cloud-standards.md
+++ b/Standards/scs-0001-v1-sovereign-cloud-standards.md
@@ -107,7 +107,7 @@ embedded in the markdown header.
 | Field name      | Requirement                                                                | Description                                                                           |
 | --------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `type`          | REQUIRED                                                                   | one of `Procedural`, `Standard`, `Decision Record`, or `Supplement`                   |
-| `status`        | REQUIRED                                                                   | one of `Draft`, `Stable`, `Deprecated`, or `Rejected`                                 |
+| `status`        | REQUIRED precisely when `type` is not `Supplement`                         | one of `Draft`, `Stable`, `Deprecated`, or `Rejected`                                 |
 | `track`         | REQUIRED                                                                   | one of `Global`, `IaaS`, `KaaS`, `IAM`, `Ops`                                         |
 | `supplements`   | REQUIRED precisely when `type` is `Supplement`                             | list of documents that are extended by this document (e.g., multiple major versions)  |
 | `deprecated_at`  | REQUIRED if `status` is `Deprecated`                                       | ISO formatted date indicating the date after which the deprecation is in effect       |
@@ -193,7 +193,9 @@ In case there is little or no activity in some team, the SIG Standardization/Cer
 can take decisions on behalf of such a team. The SIG will seek alignment with the Project
 Board for decisions with large impact to ensure we have the wanted broad alignment.
 
-Supplements may be kept in Draft state, because they are not authoritative.
+From this perspective,
+Supplements are perpetually kept in Draft state, because they are not authoritative,
+and this state is not recorded in the document (i.e., no Status field).
 
 ### Proposal phase
 
@@ -223,8 +225,9 @@ for a Supplement of `scs-0100-v3-flavor-naming.md`,
 the file name might be `scs-0100-w1-flavor-naming-implementation-testing.md` (note the `w1`!).
 
 The metadata MUST indicate the intended `track` and `type` of the document,
-and the `status` MUST be set to `Draft`;
-for a Supplement, the `supplements` field MUST be set
+and the `status` MUST be set to `Draft`,
+except for a Supplement;
+where, instead, the `supplements` field MUST be set
 to a list of documents (usually containing one element).
 
 Upon acceptance by the group of people identified by the `track`,

--- a/Standards/scs-0001-v1-sovereign-cloud-standards.md
+++ b/Standards/scs-0001-v1-sovereign-cloud-standards.md
@@ -194,8 +194,8 @@ can take decisions on behalf of such a team. The SIG will seek alignment with th
 Board for decisions with large impact to ensure we have the wanted broad alignment.
 
 From this perspective,
-Supplements are perpetually kept in `Draft` state, because they are not authoritative,
-and this state is not recorded in the document (i.e., no `status` field).
+Supplements are perpetually kept in phase Draft, because they are not authoritative,
+and this phase is not recorded in the document (i.e., no `status` field).
 
 ### Proposal phase
 

--- a/Standards/scs-0001-v1-sovereign-cloud-standards.md
+++ b/Standards/scs-0001-v1-sovereign-cloud-standards.md
@@ -194,8 +194,8 @@ can take decisions on behalf of such a team. The SIG will seek alignment with th
 Board for decisions with large impact to ensure we have the wanted broad alignment.
 
 From this perspective,
-Supplements are perpetually kept in Draft state, because they are not authoritative,
-and this state is not recorded in the document (i.e., no Status field).
+Supplements are perpetually kept in `Draft` state, because they are not authoritative,
+and this state is not recorded in the document (i.e., no `status` field).
 
 ### Proposal phase
 

--- a/Standards/scs-0004-w1-achieving-certification-implementation.md
+++ b/Standards/scs-0004-w1-achieving-certification-implementation.md
@@ -2,7 +2,6 @@
 title: "Implementation hints for achieving SCS-compatible certification"
 type: Supplement
 track: Global
-status: Draft
 supplements:
   - scs-0004-v1-achieving-certification.md
 ---

--- a/Standards/scs-0007-w1-certification-integrators-implementation-notes.md
+++ b/Standards/scs-0007-w1-certification-integrators-implementation-notes.md
@@ -2,7 +2,6 @@
 title: "Implementation hints for achieving Certified SCS Integrator"
 type: Supplement
 track: Global
-status: Stable
 supplements:
   - scs-0007-v1-certification-integrators.md
 ---

--- a/Standards/scs-0100-w1-flavor-naming-implementation-testing.md
+++ b/Standards/scs-0100-w1-flavor-naming-implementation-testing.md
@@ -22,12 +22,12 @@ Every flavor whose name starts with `SCS-` must conform with the naming scheme l
 
 #### Syntax check
 
-The [test suite](https://github.com/SovereignCloudStack/standards/tree/main/Tests/iaas/flavor-naming)
+The [test suite](https://github.com/SovereignCloudStack/standards/tree/main/Tests/iaas/scs_0100_flavor_naming)
 comes with a handy
-[command-line utility](https://github.com/SovereignCloudStack/standards/tree/main/Tests/iaas/flavor-naming/cli.py)
+[command-line utility](https://github.com/SovereignCloudStack/standards/tree/main/Tests/iaas/scs_0100_flavor_naming/cli.py)
 that can be used to validate flavor names, to interactively construct a flavor name
 via a questionnaire, and to generate prose descriptions for given flavor names.
-See the [README](https://github.com/SovereignCloudStack/standards/tree/main/Tests/iaas/flavor-naming/README.md)
+See the [README](https://github.com/SovereignCloudStack/standards/tree/main/Tests/iaas/scs_0100_flavor_naming/README.md)
 for more details.
 
 The functionality of this script is also (partially) exposed via the web page

--- a/Standards/scs-0100-w1-flavor-naming-implementation-testing.md
+++ b/Standards/scs-0100-w1-flavor-naming-implementation-testing.md
@@ -2,7 +2,6 @@
 title: "SCS Flavor Naming Standard: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0100-v1-flavor-naming.md
   - scs-0100-v2-flavor-naming.md

--- a/Standards/scs-0101-w1-entropy-implementation-testing.md
+++ b/Standards/scs-0101-w1-entropy-implementation-testing.md
@@ -2,7 +2,6 @@
 title: "SCS Entropy: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0101-v1-entropy.md
 ---

--- a/Standards/scs-0102-w1-image-metadata-implementation-testing.md
+++ b/Standards/scs-0102-w1-image-metadata-implementation-testing.md
@@ -2,7 +2,6 @@
 title: "SCS Image Metadata: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0102-v1-image-metadata.md
 ---

--- a/Standards/scs-0103-w1-standard-flavors-implementation.md
+++ b/Standards/scs-0103-w1-standard-flavors-implementation.md
@@ -2,7 +2,6 @@
 title: "SCS Standard Flavors: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0103-v1-standard-flavors.md
 ---

--- a/Standards/scs-0104-w1-standard-images-implementation.md
+++ b/Standards/scs-0104-w1-standard-images-implementation.md
@@ -2,7 +2,6 @@
 title: "SCS Standard Images: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0104-v1-standard-images.md
 ---

--- a/Standards/scs-0114-w1-volume-type-implementation.md
+++ b/Standards/scs-0114-w1-volume-type-implementation.md
@@ -2,7 +2,6 @@
 title: "SCS Volume Types: Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0114-v1-volume-type-standard.md
 ---

--- a/Standards/scs-0115-w1-security-groups-implementation.md
+++ b/Standards/scs-0115-w1-security-groups-implementation.md
@@ -2,7 +2,6 @@
 title: "Default Rules for Security Groups: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0115-v1-default-rules-for-security-groups.md
 ---

--- a/Standards/scs-0116-w1-key-manager-implementation-testing.md
+++ b/Standards/scs-0116-w1-key-manager-implementation-testing.md
@@ -2,7 +2,6 @@
 title: "SCS Key Manager Standard: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0116-v1-key-manager-standard.md
 ---

--- a/Standards/scs-0117-w1-volume-backup-service-implementation.md
+++ b/Standards/scs-0117-w1-volume-backup-service-implementation.md
@@ -2,7 +2,6 @@
 title: "Volume Backup Functionality: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0117-v1-volume-backup-service.md
 ---

--- a/Standards/scs-0118-w1-example-impacts-of-failure-scenarios.md
+++ b/Standards/scs-0118-w1-example-impacts-of-failure-scenarios.md
@@ -2,7 +2,6 @@
 title: "SCS Taxonomy of Failsafe Levels: Examples of Failure Cases and their impact on IaaS and KaaS resources"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0118-v1-taxonomy-of-failsafe-levels.md
 ---

--- a/Standards/scs-0121-w1-Availability-Zones-Standard.md
+++ b/Standards/scs-0121-w1-Availability-Zones-Standard.md
@@ -2,7 +2,6 @@
 title: "SCS Availability Zones: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0121-v1-Availability-Zones-Standard.md
 ---

--- a/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
+++ b/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
@@ -2,7 +2,6 @@
 title: "Mandatory and Supported IaaS Services: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0123-v1-mandatory-and-supported-IaaS-services.md
 ---

--- a/Standards/scs-0124-w1-security-of-iaas-service-software.md
+++ b/Standards/scs-0124-w1-security-of-iaas-service-software.md
@@ -2,7 +2,6 @@
 title: "SCS Standard for the security of IaaS service software: Implementation and Testing Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0124-v1-security-of-iaas-service-software.md
 ---

--- a/Standards/scs-0126-w1-provider-networks-implementation.md
+++ b/Standards/scs-0126-w1-provider-networks-implementation.md
@@ -2,7 +2,6 @@
 title: "Provider Network Standard: Implementation Notes"
 type: Supplement
 track: IaaS
-status: Draft
 supplements:
   - scs-0126-v1-provider-networks.md
 ---

--- a/Standards/scs-0210-w1-k8s-version-policy-implementation-testing.md
+++ b/Standards/scs-0210-w1-k8s-version-policy-implementation-testing.md
@@ -2,7 +2,6 @@
 title: "SCS K8S Version Policy: Implementation and Testing Notes"
 type: Supplement
 track: KaaS
-status: Draft
 supplements:
   - scs-0210-v2-k8s-version-policy.md
 ---

--- a/Standards/scs-0211-w1-kaas-default-storage-class-implementation-testing.md
+++ b/Standards/scs-0211-w1-kaas-default-storage-class-implementation-testing.md
@@ -2,7 +2,6 @@
 title: "SCS KaaS default storage class: Implementation and Testing Notes"
 type: Supplement
 track: KaaS
-status: Draft
 supplements:
   - scs-0211-v1-kaas-default-storage-class.md
 ---

--- a/Standards/scs-0214-w1-k8s-node-distribution-implementation-testing.md
+++ b/Standards/scs-0214-w1-k8s-node-distribution-implementation-testing.md
@@ -2,7 +2,6 @@
 title: "Kubernetes Node Distribution and Availability: Implementation and Testing Notes"
 type: Supplement
 track: KaaS
-status: Draft
 supplements:
   - scs-0214-v1-k8s-node-distribution.md
   - scs-0214-v2-k8s-node-distribution.md

--- a/Standards/scs-0219-w1-kaas-networking.md
+++ b/Standards/scs-0219-w1-kaas-networking.md
@@ -2,7 +2,6 @@
 title: "KaaS Networking Standard: Implementation Notes"
 type: Supplement
 track: KaaS
-status: Draft
 supplements:
   - scs-0219-v1-kaas-networking.md
 ---

--- a/Standards/scs-0302-w1-domain-manager-implementation-notes.md
+++ b/Standards/scs-0302-w1-domain-manager-implementation-notes.md
@@ -2,7 +2,6 @@
 title: Domain Manager implementation notes
 type: Supplement
 track: IAM
-status: Draft
 supplements:
   - scs-0302-v1-domain-manager-role.md
 ---

--- a/Tests/chk_adrs.py
+++ b/Tests/chk_adrs.py
@@ -118,7 +118,6 @@ class Checker:
         if front is None:
             self.emit(f"in {fn}: is missing front matter altogether")
             return
-        # so far, only check primary documents, not supplemental ones
         if fn[9] == 'w':
             return self._check_front_matter_supplement(fn, front, filenames)
         if fn[9] != 'v':

--- a/Tests/chk_adrs.py
+++ b/Tests/chk_adrs.py
@@ -96,7 +96,21 @@ class Checker:
             if len(fns) > 1:
                 self.emit(f"duplicate stable: {fns}")
 
-    def check_front_matter(self, fn, front):
+    def _check_front_matter_supplement(self, fn, front, filenames):
+        typ = front.get('type')
+        if typ != "Supplement":
+            self.emit(f"in {fn}: type must be Supplement, is {typ}")
+        if 'status' in front:
+            self.emit(f"in {fn}: Supplement shouldn't have status field")
+        supplements = front.get("supplements")
+        if not isinstance(supplements, list):
+            self.emit(f"in {fn}: field 'supplements' must be a list")
+        # NOTE could check that each entry refers to a file that exists
+        for fn2 in supplements:
+            if fn2 not in filenames:
+                self.emit("in {fn}: field 'supplements' refers to unknown {fn2}")
+
+    def check_front_matter(self, fn, front, filenames):
         """Check the dict `front` of front matter
 
         The argument `fn` is mainly for context in error messages, but also to distinguish document types.
@@ -105,6 +119,8 @@ class Checker:
             self.emit(f"in {fn}: is missing front matter altogether")
             return
         # so far, only check primary documents, not supplemental ones
+        if fn[9] == 'w':
+            return self._check_front_matter_supplement(fn, front, filenames)
         if fn[9] != 'v':
             print(f"skipping non-primary {fn}", file=sys.stderr)
             return
@@ -151,7 +167,7 @@ def main(argv):
     checker = Checker()
     for fn in mds:
         checker.check_name(fn)
-        checker.check_front_matter(fn, _load_front_matter(os.path.join(path, fn)))
+        checker.check_front_matter(fn, _load_front_matter(os.path.join(path, fn)), mds)
     checker.check_names(mds)
     return checker.errors
 


### PR DESCRIPTION
This field causes some confusion for Supplement docs, for the standard scs-0001-v1 merely states that these docs may be kept in Draft state, which provides no certainty as to what should be done. Here, I propose to go for maximum certainty by simply stating they are kept in Draft state in perpetuity, and therefore, the field is not even present in them.