### PR TITLE
Publish up-to-date image for compliance checks

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -36,6 +36,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=ref,event=branch
+            type=sha
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
To keep the image up to date this adds running the workflow on pushes to main. I've added the more commonly used tag `latest`, `main` is kept for comparability.

To allow for downgrades/version pinning where desired, this adds tagged images using the short commit SHA.