### PR TITLE
Bugfix: use correct URI for Debian security archive mirror

### DIFF
--- a/Tests/iaas/scs_0101_entropy/entropy_check.py
+++ b/Tests/iaas/scs_0101_entropy/entropy_check.py
@@ -54,7 +54,10 @@ SERVER_USERDATA = {
     'debian': SERVER_USERDATA_GENERIC.replace('# apt-placeholder', """apt:
   primary:
     - arches: [default]
-      uri: https://mirror.plusserver.com/debian/debian/"""),
+      uri: https://mirror.plusserver.com/debian/debian/
+  security:
+    - arches: [default]
+      uri: https://mirror.plusserver.com/debian/debian-security/"""),
 }
 
 


### PR DESCRIPTION
Solves #1001.

thanks to @cpt-kernel-afk for reporting and @neuroserve for investigating!