### PR TITLE
fix property name in cloud config template

### DIFF
--- a/playbooks/clouds.yaml.j2
+++ b/playbooks/clouds.yaml.j2
@@ -11,7 +11,7 @@ clouds:
     auth_type: "v3applicationcredential"
   artcodix:
     interface: public
-    identity_api_verion: 3
+    identity_api_version: 3
     auth_type: "v3applicationcredential"
     region_name: "MUC"
     auth:
@@ -21,7 +21,7 @@ clouds:
       #project_id: 225a7363dab74b69aa1e3f744aced109
   artcodix-ro:
     interface: public
-    identity_api_verion: 3
+    identity_api_version: 3
     auth_type: "v3applicationcredential"
     region_name: "RO"
     auth:
@@ -84,7 +84,7 @@ clouds:
     auth_type: "v3applicationcredential"
   poc-wgcloud:
     interface: public
-    identity_api_verion: 3
+    identity_api_version: 3
     auth_type: "v3applicationcredential"
     #region_name: default
     auth:
@@ -112,7 +112,7 @@ clouds:
     identity_api_version: 3
   syseleven-dus2:
     interface: public
-    identity_api_verion: 3
+    identity_api_version: 3
     auth_type: "v3applicationcredential"
     region_name: dus2
     auth:
@@ -121,7 +121,7 @@ clouds:
       application_credential_secret: "{{ clouds_conf.syseleven_dus2_ac_secret }}"
   syseleven-ham1:
     interface: public
-    identity_api_verion: 3
+    identity_api_version: 3
     auth_type: "v3applicationcredential"
     region_name: ham1
     auth:


### PR DESCRIPTION
I stumbled over this little typo. Seems not to be a real issue as of now, but it may avoid problems in the future.