### PR TITLE
Add jschoone to SCS PB 2026 nominees

### DIFF
--- a/Community-Governance/2025-12-project-board-nominees.md
+++ b/Community-Governance/2025-12-project-board-nominees.md
@@ -6,3 +6,4 @@ For the term 2025-12 - 2026-12 the following people are nominated / have nominat
 | ------------------- | -------------- | ----------------------------------- |
 | Garloff, Kurt       | @garloff       | <scs@garloff.de>                    |
 | Klare, Jan          | @jklare        | <klare@osism.tech>                  |
+| Schoone, Jan        | @jschoone      | <jan.schoone@uhurutec.com>          |


### PR DESCRIPTION
Moin,
I'd like to continue the work in the SCS Project Board, mainly regarding the Container Layer.
2025 was the first year for SCS in the new structure without the previous funding, this presented us with a number of challenges, from which we were able to gain valuable learnings for the next iteration, to keep the community and the reference implementation running.