### PR TITLE
Stabilize SCS-0005-v2 and deprecate v1

### DIFF
--- a/Standards/scs-0005-v1-project-governance.md
+++ b/Standards/scs-0005-v1-project-governance.md
@@ -1,8 +1,9 @@
 ---
 title: Governance of the SCS community
 type: Procedural
-status: Stable
+status: Deprecated
 stabilized_at: 2025-01-16
+deprecated_at: 2025-12-16
 track: Global
 description: |
   SCS-0005 outlines the structure and governance of the SCS community by the SCS Project Board and how this is elected.

--- a/Standards/scs-0005-v2-project-governance.md
+++ b/Standards/scs-0005-v2-project-governance.md
@@ -1,7 +1,8 @@
 ---
 title: Governance of the SCS community
 type: Procedural
-status: Draft
+status: Stable
+stabilized_at: 2025-12-16
 replaces: scs-0005-v1-project-governance.md
 track: Global
 description: |


### PR DESCRIPTION
Promote SCS-0005-v2 project governance standard from Draft to Stable status and mark SCS-0005-v1 as Deprecated, as v2 now replaces it.