### PR TITLE
Kurt Garloff is the spokesperson for the term 2026.

### DIFF
--- a/Community-Governance/2026-01-project-board-termin-2026.md
+++ b/Community-Governance/2026-01-project-board-termin-2026.md
@@ -1,6 +1,6 @@
 # Project Board Term 2026
 
-Spokesperson:
+Spokesperson: Kurt Garloff, @garloff
 
 | Name, Firstname         | Github Handle  | E-Mail                              | Remark                         |
 | ----------------------- | -------------- | ----------------------------------- |---------------------------------


### PR DESCRIPTION
This was discussed in the initial meeting of the PB 2026 on January 12th.