### PR TITLE
Update AppCreds for SCS2, PCO Prod1,2,3,4, WaveStack.

### DIFF
--- a/.zuul.d/secure.yaml
+++ b/.zuul.d/secure.yaml
@@ -344,14 +344,16 @@
           QuBI13w+WI9mGYQw1iin91IvySs08CTEMyzQz/qGkoDnp6gNomxhTDK57u3379RIHfI6Z
           yc3cQ0o2uiw2csNkmmRL6HrRui33U09NHYsoBrkNErHGM/QGfd0l0kmK2pd5nA=
       scs2_ac_id: !encrypted/pkcs1-oaep
-        - or1s9BIyudJS5Qs67isfma/1G6AvUgBIUr+5mAfL53IjXI+CFKm01IIuOxCoLGE8H/MOY
-          i7jmsnzbiYdobA0IPTuqUU6eCIOzX3q3jumu7TUDDrsRQ7nGFJxChS9bDIsHToQuIEXE7
-          K3trzKnjoXZ2EPaKxvAGI2JyO6UCFVgiDo1SUBN9yUzg/6Lh7m2EvUh19VkQoNMXGK83j
-          P/Y9GAyNaM6Uv7glY+Ip4ZtWayBke+DcE+4oHzhLg7rMeHkuQCLrtkE+jPgnqz9uyXw6Q
-          32v086Vqz9qNTXQOhIkc3dq3efjPy08DEn9mvuFTHCJLgizvT/zT0p0PkAytmpGcfq51s
-          Hahc3PU3+it8N4owUPEwm9NGFYTV7NBJPfcfP01W58+W0m2DUCpk98TGAGzahrhoKFHif
-          dTi2JJ7dQ1qHq1bwKgD9yDjVUGyXj8XcHZ6c54CTbAKbL83IL/w+FXLE2oAEbzocVgUoD
-          IMWBpxN5rXpNbroDaiRMpT5+7o3PJIKoJMflb72+uTOH2hQ3zRwBr18d3KTT/duZFh0QV
+        - K4lCQyF6ou6848rCbhLY2RzPD0GANOF05PpWaEgrSSw9jA0G7ogx74hRke4J5BhhAGW4D
+          mJHsPu9tFSgLktnivKesddhh7BEpiQ/hXweK8ulL+G6VFw612HP5nAXA7dqGaH/O9B4hs
+          dgkKwP2fQ9+6QPsqty16OZfe0Vq76nkLwxuGH8jt+hiJM5Tr6QTzfMnAGE2h4D+gWsRN+
+          mF6fXAasnKZmqSBqI+5UdbDSbC9zoULUqOUKeZGIb8QBNfKG191SDws4Yrj0ZjAbEc3LY
+          OOIAWlMOaTWguUlhks+q3YxBuKSJu2WgjswoLJIfApy8L0GordRcGhCM7EjsW7AL8TaS0
+          ehFdqRg3cAobYxnyI6kwwijVb7Ayt4l4A8j/SWMUx0M0/n3DuOgdj2qLnBbQM/N7hWmNi
+          OO/9Rq2xQZvbSPE5gUmXboEjuy0CMked1NnNdbAXmH/x0bz9R/KXNpWLpmiH271E44QzX
+          G9hS6xOPGPX/IZyguSAf2jqOPlbssQOuCyaEiBjJT6jZ4OWmjb4fCVpmIXFDZCK4NFh8F
+          oNaJYqK6Zuoq/AXDo0zeaUmcL3yxM9aZeNvwmKnunJrgUeBoCdPryLpJ3iVCeJ9qD0m6t
+          NR57ievrR5wJyOVEBpfxl0nfPQFKSPcSDD3fkZ4Fm/hKe3RDmLMcA0DLEydEog=
       scs2_ac_secret: !encrypted/pkcs1-oaep
         - AGjXdJun09ICmcT7COGntE6uX8/EYdcrpFHgbBL4RchmKVOdDRj5Ap6Oex3ftOkcYZxpJ
           3TB/8QgNDEb2bysz8GsR4Mdwq8a5M2eAAP/7clzyy2SzfDOtf9MFOo10MTmPjZRzTkriu


### PR DESCRIPTION
The old ones have expired, these will last until the end of 2026.