### PR TITLE
Migrate SCS-compatible IaaS v3 through v5.1 to fine-grained testcases

### DIFF
--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -265,13 +265,63 @@ modules:
     parameters:
       image_spec: address (URL) of an image-spec (YAML) file
     run:
-      - executable: ./iaas/openstack_test.py
-        args: -c {os_cloud} standard-images-check/1
+    - executable: ./iaas/openstack_test.py
+      args: >
+        -c {os_cloud}
+        scs-0104-source-capi-1 scs-0104-source-capi-2
+        scs-0104-source-ubuntu-2404 scs-0104-source-ubuntu-2204 scs-0104-source-ubuntu-2004
+        scs-0104-source-debian-13 scs-0104-source-debian-12 scs-0104-source-debian-11
+        scs-0104-image-capi-2 scs-0104-image-capi-1
+        scs-0104-image-ubuntu-2404 scs-0104-image-ubuntu-2204
+        scs-0104-image-debian-13 scs-0104-image-debian-12
+        standard-images-check/1
     testcases:
-      - id: standard-images-check
-        tags: [legacy_mandatory]
-        description: >
-          Must fulfill all requirements of <https://docs.scs.community/standards/scs-0104-v1-standard-images>
+    - id: scs-0104-source-capi-1
+      tags: [mandatory]
+      description: CAPI images adhere to canonical image source
+    - id: scs-0104-source-capi-2
+      tags: [mandatory]
+      description: CAPI images adhere to canonical image source
+    - id: scs-0104-source-ubuntu-2404
+      tags: [mandatory]
+      description: Ubuntu 24.04 images adhere to canonical image source
+    - id: scs-0104-source-ubuntu-2204
+      tags: [mandatory]
+      description: Ubuntu 22.04 images adhere to canonical image source
+    - id: scs-0104-source-ubuntu-2004
+      tags: [mandatory]
+      description: Ubuntu 20.04 images adhere to canonical image source
+    - id: scs-0104-source-debian-13
+      tags: [mandatory]
+      description: Debian 13 images adhere to canonical image source
+    - id: scs-0104-source-debian-12
+      tags: [mandatory]
+      description: Debian 12 images adhere to canonical image source
+    - id: scs-0104-source-debian-11
+      tags: [mandatory]
+      description: Debian 11 images adhere to canonical image source
+    - id: scs-0104-image-capi-2
+      tags: []
+      description: CAPI image is present (naming scheme v2)
+    - id: scs-0104-image-capi-1
+      tags: [recommended]
+      description: CAPI image is present (naming scheme v1)
+    - id: scs-0104-image-ubuntu-2404
+      tags: []
+      description: Ubuntu 24.04 image is present (by name)
+    - id: scs-0104-image-ubuntu-2204
+      tags: [mandatory]
+      description: Ubuntu 22.04 image is present (by name)
+    - id: scs-0104-image-debian-13
+      tags: []
+      description: Debian 13 image is present (by name)
+    - id: scs-0104-image-debian-12
+      tags: []
+      description: Debian 12 image is present (by name)
+    - id: standard-images-check
+      tags: [legacy_mandatory]
+      description: >
+        Must fulfill all requirements of <https://docs.scs.community/standards/scs-0104-v1-standard-images>
   - id: scs-0104-v1-2
     name: Standard images
     url: https://docs.scs.community/standards/scs-0104-v1-standard-images


### PR DESCRIPTION
This is possible because since the introduction of 'next', the fine-grained testcases have been reported -- even for the older versions.