### PR TITLE
Fix/improve flakiness of scs-0101 tests

### DIFF
--- a/Tests/iaas/scs_0101_entropy/entropy_check.py
+++ b/Tests/iaas/scs_0101_entropy/entropy_check.py
@@ -349,7 +349,6 @@ def _convert_to_collected(lines, marker=MARKER):
     # HOWEVER, concurrent processes can easily disturb this pattern, so we use a
     # unique prefix on each line ourselves.
     section = None
-    indent = 0
     collected = {}
     for line in lines:
         idx = line.find(marker)


### PR DESCRIPTION
The console output inside the VM is quite easily disrupted by concurrent processes. This makes finding the relevant output quite complicated. The heuristics for this task was not optimal; let's hope this one is better.