### PR TITLE
Fix missing group 'syself'

### DIFF
--- a/compliance-monitor/bootstrap.yaml
+++ b/compliance-monitor/bootstrap.yaml
@@ -96,11 +96,14 @@ accounts:
         public_key_type: "ssh-ed25519"
         public_key_name: "primary"
   - subject: syself-1.32
+    group: syself
     delegates:
       - zuul_ci
   - subject: syself-1.31
+    group: syself
     delegates:
       - zuul_ci
   - subject: syself-1.30
+    group: syself
     delegates:
       - zuul_ci


### PR DESCRIPTION
It's a good idea to declare a group for related subjects, such as different regions of the same IaaS product or different k8s versions of the same KaaS product. Once this change is live on the server, details for the whole group can be requested under:

https://compliance.sovereignit.cloud/page/detail_full/group-syself/1fffebe6-fd4b-44d3-a36c-fc58b4bb0180

It will be similar to this page:

https://compliance.sovereignit.cloud/page/detail_full/group-pco-prod/50393e6f-2ae1-4c5c-a62c-3b75f2abef3f