### PR TITLE
SCS-0123-v2: Clarify mandatory service types

### DIFF
--- a/Standards/scs-0123-v1-mandatory-and-supported-IaaS-services.md
+++ b/Standards/scs-0123-v1-mandatory-and-supported-IaaS-services.md
@@ -26,9 +26,10 @@ Any unsupported APIs will not be tested.
 
 ## Mandatory IaaS APIs
 
-The following IaaS APIs MUST be present in SCS-compliant IaaS deployments and could be implemented with the corresponding OpenStack services:
+The following IaaS APIs MUST be present in SCS-compliant IaaS deployments and could be implemented with the corresponding OpenStack services.
+The endpoints of services MUST be findable through the `catalog list` of the identity API[^1].
 
-| Mandatory API | corresponding OpenStack Service | description |
+| Mandatory API service type | corresponding OpenStack Service | description |
 |-----|-----|-----|
 | **block-storage** | Cinder | Block Storage service |
 | **compute** | Nova | Compute service |
@@ -36,35 +37,26 @@ The following IaaS APIs MUST be present in SCS-compliant IaaS deployments and co
 | **image** | Glance | Image service |
 | **load-balancer** | Octavia | Load-balancer service |
 | **network** | Neutron | Networking service |
-| **s3** | S3 API object storage | Object Storage service |
+| **s3**[^2] | N/A | s3 compatible Object Storage service |
 
-:::caution
-
-S3 API implementations may differ in certain offered features.
-CSPs must publicly describe the endpoints of their S3 solutions and which implementations they use in their deployment.
-Users should always research whether a needed feature is supported in the offered implementation.
-
-:::
-
-The endpoints of services MUST be findable through the `catalog list` of the identity API[^1].
-
-[^1]: [Integrate into the service catalog of Keystone](https://docs.openstack.org/keystone/latest/contributor/service-catalog.html)
+Aliases for these service types are only permitted where defined by the [OpenStack Service Type Authority](https://specs.openstack.org/openstack/service-types-authority/#aliases-optional).
+Catalog entries SHOULD use the canonical service type, not aliases.
 
 ## Supported IaaS APIs
 
-The following IaaS APIs MAY be present in SCS-compliant IaaS deployment, e.g. implemented thorugh the corresponding OpenStack services, and are considered in the SCS standards.
+The following IaaS APIs MAY be present in SCS-compliant IaaS deployment, e.g. implemented through the corresponding OpenStack services, and are considered in the SCS standards.
 
-| Supported API | corresponding OpenStack Service | description |
+| Supported API service type | corresponding OpenStack Service | description |
 |-----|-----|-----|
-| **bare-metal** | Ironic | Bare Metal provisioning service |
-| **billing** | CloudKitty | Rating/Billing service |
+| **baremetal** | Ironic | Bare Metal provisioning service |
+| **rating** | CloudKitty | Rating/Billing service |
 | **dns** | Designate | DNS service |
-| **ha** | Masakari | Instances High Availability service |
+| **instance-ha** | Masakari | Instances High Availability service |
 | **key-manager** | Barbican | Key Manager service |
 | **object-store** | Swift | Object Store with different possible backends |
 | **orchestration** | Heat | Orchestration service |
-| **shared-file-systems** | Manila | Shared File Systems service |
-| **time-series-database** | Gnocchi | Time Series Database service |
+| **shared-file-system** | Manila | Shared File Systems service |
+| **time-series-database**[^2] | Gnocchi | Time Series Database service |
 
 ## Unsupported IaaS APIs
 
@@ -76,7 +68,5 @@ The SCS standard offers no guarantees for compatibility or reliability of servic
 
 [The OpenStack Services](https://www.openstack.org/software/)
 
-## Conformance Tests
-
-The presence of the mandatory OpenStack APIs will be tested in [this test-script](https://github.com/SovereignCloudStack/standards/blob/main/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py)
-The test will further check whether the object-store endpoint is compatible to s3.
+[^1]: [Integrate into the service catalog of Keystone](https://docs.openstack.org/keystone/latest/contributor/service-catalog.html)
+[^2]: These service types have not been assigned by the OpenStack Service Type Authority

--- a/Standards/scs-0123-v2-services.md
+++ b/Standards/scs-0123-v2-services.md
@@ -36,7 +36,7 @@ The endpoints of services MUST be findable through the `catalog list` of the ide
 | **image** | Glance | Image service |
 | **load-balancer** | Octavia | Load-balancer service |
 | **network** | Neutron | Networking service |
-| **s3**[^2] | N/A | s3 compatible Object Storage service |
+| **object-store-s3**[^2] | N/A | s3 compatible Object Storage service |
 
 Aliases for these service types are only permitted where defined by the [OpenStack Service Type Authority](https://specs.openstack.org/openstack/service-types-authority/#aliases-optional).
 Catalog entries SHOULD use the canonical service type, not aliases.

--- a/Standards/scs-0123-v2-services.md
+++ b/Standards/scs-0123-v2-services.md
@@ -1,8 +1,7 @@
 ---
 title: Mandatory and Supported IaaS Services
 type: Standard
-status: Stable
-stabilized_at: 2024-11-20
+status: Draft
 track: IaaS
 ---
 
@@ -26,9 +25,10 @@ Any unsupported APIs will not be tested.
 
 ## Mandatory IaaS APIs
 
-The following IaaS APIs MUST be present in SCS-compliant IaaS deployments and could be implemented with the corresponding OpenStack services:
+The following IaaS APIs MUST be present in SCS-compliant IaaS deployments and could be implemented with the corresponding OpenStack services.
+The endpoints of services MUST be findable through the `catalog list` of the identity API[^1].
 
-| Mandatory API | corresponding OpenStack Service | description |
+| Mandatory API service type | corresponding OpenStack Service | description |
 |-----|-----|-----|
 | **block-storage** | Cinder | Block Storage service |
 | **compute** | Nova | Compute service |
@@ -36,35 +36,26 @@ The following IaaS APIs MUST be present in SCS-compliant IaaS deployments and co
 | **image** | Glance | Image service |
 | **load-balancer** | Octavia | Load-balancer service |
 | **network** | Neutron | Networking service |
-| **s3** | S3 API object storage | Object Storage service |
+| **s3**[^2] | N/A | s3 compatible Object Storage service |
 
-:::caution
-
-S3 API implementations may differ in certain offered features.
-CSPs must publicly describe the endpoints of their S3 solutions and which implementations they use in their deployment.
-Users should always research whether a needed feature is supported in the offered implementation.
-
-:::
-
-The endpoints of services MUST be findable through the `catalog list` of the identity API[^1].
-
-[^1]: [Integrate into the service catalog of Keystone](https://docs.openstack.org/keystone/latest/contributor/service-catalog.html)
+Aliases for these service types are only permitted where defined by the [OpenStack Service Type Authority](https://specs.openstack.org/openstack/service-types-authority/#aliases-optional).
+Catalog entries SHOULD use the canonical service type, not aliases.
 
 ## Supported IaaS APIs
 
-The following IaaS APIs MAY be present in SCS-compliant IaaS deployment, e.g. implemented thorugh the corresponding OpenStack services, and are considered in the SCS standards.
+The following IaaS APIs MAY be present in SCS-compliant IaaS deployment, e.g. implemented through the corresponding OpenStack services, and are considered in the SCS standards.
 
-| Supported API | corresponding OpenStack Service | description |
+| Supported API service type | corresponding OpenStack Service | description |
 |-----|-----|-----|
-| **bare-metal** | Ironic | Bare Metal provisioning service |
-| **billing** | CloudKitty | Rating/Billing service |
+| **baremetal** | Ironic | Bare Metal provisioning service |
+| **rating** | CloudKitty | Rating/Billing service |
 | **dns** | Designate | DNS service |
-| **ha** | Masakari | Instances High Availability service |
+| **instance-ha** | Masakari | Instances High Availability service |
 | **key-manager** | Barbican | Key Manager service |
 | **object-store** | Swift | Object Store with different possible backends |
 | **orchestration** | Heat | Orchestration service |
-| **shared-file-systems** | Manila | Shared File Systems service |
-| **time-series-database** | Gnocchi | Time Series Database service |
+| **shared-file-system** | Manila | Shared File Systems service |
+| **time-series-database**[^2] | Gnocchi | Time Series Database service |
 
 ## Unsupported IaaS APIs
 
@@ -76,7 +67,5 @@ The SCS standard offers no guarantees for compatibility or reliability of servic
 
 [The OpenStack Services](https://www.openstack.org/software/)
 
-## Conformance Tests
-
-The presence of the mandatory OpenStack APIs will be tested in [this test-script](https://github.com/SovereignCloudStack/standards/blob/main/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py)
-The test will further check whether the object-store endpoint is compatible to s3.
+[^1]: [Integrate into the service catalog of Keystone](https://docs.openstack.org/keystone/latest/contributor/service-catalog.html)
+[^2]: These service types have not been assigned by the OpenStack Service Type Authority

--- a/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
+++ b/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
@@ -11,6 +11,5 @@ supplements:
 We [implemented](https://github.com/SovereignCloudStack/standards/blob/main/Tests/iaas/openstack_test.py)
 the following testcases in accordance with the standard:
 
-- `scs-0123-service-X` (with varying `X`) ensures that a service of type X can be found in the service catalog,
-- `scs-0123-storage-apis` ensures that a service of one of the following types can be found: "volume", "volumev3", "block-storage",
-- `scs-0123-swift-s3` ensures that S3 can be used to access object storage using EC2 credentials from the identity API.
+- `scs-0123-service-<type>` ensures that a service with the given type can be found in the service catalog
+- `scs-0123-storage-apis` ensures that a service of one of the following types can be found: "volume", "volumev3", "block-storage"

--- a/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
+++ b/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
@@ -16,6 +16,7 @@ the following testcases in accordance with the standard:
 - `scs-0123-storage-apis` ensures that a service of one of the following types can be found: "volume", "volumev3", "block-storage"
 
 ### Deprecated tests
-#### v1 only
-- `scs-0123-swift-s3` ensures that S3 can be used to access object storage using EC2 credentials from the identity API
 
+#### v1 only
+
+- `scs-0123-swift-s3` ensures that S3 can be used to access object storage using EC2 credentials from the identity API

--- a/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
+++ b/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
@@ -4,6 +4,7 @@ type: Supplement
 track: IaaS
 supplements:
   - scs-0123-v1-mandatory-and-supported-IaaS-services.md
+  - scs-0123-v2-services.md
 ---
 
 ## Automated tests
@@ -13,3 +14,8 @@ the following testcases in accordance with the standard:
 
 - `scs-0123-service-<type>` ensures that a service with the given type can be found in the service catalog
 - `scs-0123-storage-apis` ensures that a service of one of the following types can be found: "volume", "volumev3", "block-storage"
+
+### Deprecated tests
+#### v1 only
+- `scs-0123-swift-s3` ensures that S3 can be used to access object storage using EC2 credentials from the identity API
+

--- a/Tests/iaas/openstack_test.py
+++ b/Tests/iaas/openstack_test.py
@@ -150,7 +150,9 @@ def make_container(cloud):
     c.add_function('scs_0123_service_load_balancer', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'load-balancer'))
     c.add_function('scs_0123_service_placement', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'placement'))
     c.add_function('scs_0123_storage_apis', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'volume', 'volumev3', 'block-storage'))
+    c.add_function('scs_0123_service_s3', lambda c: compute_scs_0123_service_presence(c.services_lookup, 's3'))
     c.add_function('scs_0123_swift_s3', lambda c: compute_scs_0123_swift_s3(c.services_lookup, c.conn))
+
     return c
 
 

--- a/Tests/iaas/openstack_test.py
+++ b/Tests/iaas/openstack_test.py
@@ -150,7 +150,7 @@ def make_container(cloud):
     c.add_function('scs_0123_service_load_balancer', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'load-balancer'))
     c.add_function('scs_0123_service_placement', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'placement'))
     c.add_function('scs_0123_storage_apis', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'volume', 'volumev3', 'block-storage'))
-    c.add_function('scs_0123_service_s3', lambda c: compute_scs_0123_service_presence(c.services_lookup, 's3'))
+    c.add_function('scs_0123_service_s3', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'object-store-s3'))
     c.add_function('scs_0123_swift_s3', lambda c: compute_scs_0123_swift_s3(c.services_lookup, c.conn))
 
     return c

--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -269,6 +269,9 @@ scripts:
   - id: scs-0123-storage-apis
     description: The block-storage API is discoverable as `volume`, `volumev3`, or `block-storage`.
     url: https://docs.scs.community/standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation#automated-tests
+  - id: scs-0123-service-s3
+    description: s3 service is discoverable.
+    url: https://docs.scs.community/standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation#automated-tests
   - id: scs-0123-swift-s3
     description: The object-storage API is compatible with S3.
     url: https://docs.scs.community/standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation#automated-tests
@@ -479,6 +482,18 @@ modules:
       - scs-0123-service-placement
       - scs-0123-storage-apis
       - scs-0123-swift-s3
+  - id: scs-0123-v2
+    name: Mandatory and Supported IaaS Services
+    url: https://docs.scs.community/standards/scs-0123-v2-services
+    targets:
+      main:
+      - scs-0123-service-compute
+      - scs-0123-service-identity
+      - scs-0123-service-image
+      - scs-0123-service-network
+      - scs-0123-service-load-balancer
+      - scs-0123-storage-apis
+      - scs-0123-service-s3
   - id: scs-0302-v1
     name: Domain Manager Role
     url: https://docs.scs.community/standards/scs-0302-v1-domain-manager-role
@@ -523,7 +538,7 @@ versions:
       - scs-0116-v1
       - scs-0117-v1
       - scs-0121-v1
-      - scs-0123-v1
+      - scs-0123-v2
       - scs-0302-v1
   - version: v5.1  # copy of v5, but with include "scs-0123-v1", which had simply been forgotten
     stabilized_at: 2024-12-19


### PR DESCRIPTION
This updates SCS-0123 to align more closely with the OpenStack Service Type Authority, and unambiguously enforces s3 services to be advertised to users via the service catalog.
I don't have a strong opinion on the specific non-canonical service type to use for that, so far "object-store-s3" had the most supporters. Other options are "s3" or, to be more in line with the service type authority guidance, "scs:s3" (namespaced).

I tried to keep the diff vs v1 to a minimum, so I copied most of the (imho somewhat redundant) prose.

I've dropped the s3 credentials testing, since I couldn't find any language in the standards that mandates the tested behavior.

Fixes #1004.