### PR TITLE
streamline CVE handling in SCS-0210 with SCS-0124

### DIFF
--- a/Standards/scs-0210-v3-k8s-version-policy.md
+++ b/Standards/scs-0210-v3-k8s-version-policy.md
@@ -3,7 +3,7 @@ title: SCS K8S Version Policy
 type: Standard
 status: Draft
 track: KaaS
-replaces: scs-0210-v2-k8s-new-version-policy.md
+replaces: scs-0210-v2-k8s-version-policy.md
 ---
 
 ## Introduction


### PR DESCRIPTION
In SCS-0124 we write:

> Critical (CVSS = 9.0 – 10.0): 3 hours
> High (CVSS = 7.0 – 8.9): 3 days
> Mid (CVSS = 4.0 – 6.9): 1 month
> Low (CVSS = 0.1 – 3.9): 3 months


Our Policies should be the same where possible, so adjust this to match IaaS.