### PR TITLE
feat: Add dynamic admission controller section to scs 0217

### DIFF
--- a/Standards/scs-0217-v1-cluster-hardening.md
+++ b/Standards/scs-0217-v1-cluster-hardening.md
@@ -316,8 +316,9 @@ via spoofing"_, NetworkPolicies and policy engine configuration doesn't suffice.
 
 These threats involve intercepting traffic between the Kubernetes API server
 and the dynamic admission controller webhooks of the Policy Engine. To mitigate
-this, the Kubernetes API server MUST be configured with mutual TLS
-authentication for the Validating and Mutating Webhooks (see [Kubernetes
+this, if using a Dynamic Admission Controller such as a Policy Engine, the
+Kubernetes API server MUST be configured with mutual TLS authentication for the
+Validating and Mutating Webhooks (see [Kubernetes
 docs](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers))
 . The Policy Engine MUST be able to authenticate the API server and MUST be
 configured with mutual TLS authentication for the


### PR DESCRIPTION
Dynamic Admission Controllers from Policy Engines constitute a special attack surface.

From the SIG security threat model, the majority of mitigations are implemented by policy engines and cluster operators.

But cluster providers must enable mutual TLS for secure consumption of Kubernetes API webhooks, and cluster operators must use a policy engine that authenticates against those TLS-terminated webhooks (not all policy engines do).