### PR TITLE
Fix error count calculation in compliance check

### DIFF
--- a/Tests/scs-compliance-check.py
+++ b/Tests/scs-compliance-check.py
@@ -231,7 +231,7 @@ class CheckRunner:
         self.num_abort += invocation["critical"]
         self.num_error += invocation["error"]
         # count failed testcases because they need not be reported redundantly on the error channel
-        self.num_error + len([value for value in invocation['results'].values() if value < 0])
+        self.num_error += len([value for value in invocation['results'].values() if value < 0])
         return invocation
 
 


### PR DESCRIPTION
I just noticed this line which can either be deleted or added via += not sure which one is correct