### PR TITLE
Adjust module opc-v2022.11 title to include scs- code

### DIFF
--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -287,7 +287,8 @@ scripts:
     url: https://docs.scs.community/standards/scs-0302-v1-domain-manager-role#conformance-tests
 modules:
   - id: opc-v2022.11
-    name: SCS end-to-end testing (formerly OpenStack-powered Compute)
+    name: >-
+      scs-0128-v1: SCS end-to-end testing (formerly OpenStack-powered Compute)
     url: https://docs.scs.community/standards/scs-0128-v1-e2e-testing
   - id: scs-0100-v3.1
     name: Flavor naming v3.1


### PR DESCRIPTION
The UI shows the code for all modules whose id begins with that code, but this is the legacy module for OpenStack-powered Compute, and I hesitate renaming it (just yet).