### PR TITLE
make test case for SCS-0123 "object-store" no longer mandatory

### DIFF
--- a/Tests/iaas/openstack_test.py
+++ b/Tests/iaas/openstack_test.py
@@ -149,7 +149,6 @@ def make_container(cloud):
     c.add_function('scs_0123_service_network', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'network'))
     c.add_function('scs_0123_service_load_balancer', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'load-balancer'))
     c.add_function('scs_0123_service_placement', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'placement'))
-    c.add_function('scs_0123_service_object_store', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'object-store'))
     c.add_function('scs_0123_storage_apis', lambda c: compute_scs_0123_service_presence(c.services_lookup, 'volume', 'volumev3', 'block-storage'))
     c.add_function('scs_0123_swift_s3', lambda c: compute_scs_0123_swift_s3(c.services_lookup, c.conn))
     return c

--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -266,9 +266,6 @@ scripts:
   - id: scs-0123-service-placement
     description: Placement service is discoverable.
     url: https://docs.scs.community/standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation#automated-tests
-  - id: scs-0123-service-object-store
-    description: Object-store service is discoverable.
-    url: https://docs.scs.community/standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation#automated-tests
   - id: scs-0123-storage-apis
     description: The block-storage API is discoverable as `volume`, `volumev3`, or `block-storage`.
     url: https://docs.scs.community/standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation#automated-tests
@@ -482,8 +479,6 @@ modules:
       - scs-0123-service-placement
       - scs-0123-storage-apis
       - scs-0123-swift-s3
-      recommended:
-      - scs-0123-service-object-store
   - id: scs-0302-v1
     name: Domain Manager Role
     url: https://docs.scs.community/standards/scs-0302-v1-domain-manager-role


### PR DESCRIPTION
Since several providers have complained that the test case for SCS-0123 "object-store" does not meet the standard (tested for being mandatory). ~~This will set it to recommended according to the standard.~~ This PR will make it no longer mandatory by removing it completely (as it is not even recommended).

"object-store" was mandatory before, as the test case for "S3" relies on “object-store” service API. As "S3" is currently skipped if no "object-store" is available, we can do this change to be in line with the standard. However, this should not prevent anyone from offering S3. This problem is already tackled in #1004 and #1093.

Fixes #1110