### PR TITLE
Remove myself from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-*                      @mbuechse @depressiveRobot @fkr @garloff	
+*                      @depressiveRobot @fkr @garloff	
 
-/compliance-monitor/   @mbuechse @depressiveRobot
+/compliance-monitor/   @depressiveRobot
 
-/Tests/                @mbuechse @depressiveRobot
+/Tests/                @depressiveRobot
 
 # Members of the Project Board are the owners of the Community
 # Governance - see: 


### PR DESCRIPTION
I don't feel I as a code owner have the necessary control
(for instance, I can be blocked by arbitrary change requests,
which has been draining my energy lately)
-- so I reject this label.