### PR TITLE
Fix handling of self-signed certs in s3_conn

### DIFF
--- a/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
+++ b/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
@@ -28,12 +28,13 @@ def compute_scs_0123_service_presence(services_lookup, *names):
 
 def s3_conn(creds, conn):
     """Return an s3 client conn"""
+    insecure = conn.config.config.get("insecure")
+    verify = conn.config.config.get("verify")
     cacert = conn.config.config.get("cacert")
-    # TODO: Handle self-signed certs (from ca_cert in openstack config)
-    if cacert:
-        logger.warning(f"Trust all Certificates in S3, OpenStack uses {cacert}")
+    vrfy = False if (insecure is True or verify is False) else \
+        (cacert or (verify if isinstance(verify, str) else None))
     return boto3.resource(
-        's3', endpoint_url=creds["HOST"], verify=not cacert,
+        's3', endpoint_url=creds["HOST"], verify=vrfy,
         aws_access_key_id=creds["AK"], aws_secret_access_key=creds["SK"],
     )
 

--- a/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
+++ b/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
@@ -30,12 +30,15 @@ def s3_conn(creds, conn):
     """Return an s3 client conn"""
     cfg = conn.config.config
     # Take insecure/verify/cacert parameter from clouds.yaml and pass it to boto3.resource.
-    # Deliberately do un-Pythonic `is True` and `is False` here because of type mayhem:
-    # for instance, handle verify=False differently from verify=None (or not set) or verify='some.ca'.
-    if cfg.get("insecure") is True or cfg.get("verify") is False:
+    # If verify is True in clouds.yaml, fall back to cacert or None. In the latter case,
+    # the default boto3 behavior is applied (e.g., REQUESTS_CA_BUNDLE can still be used);
+    # but for that, verify must be `None` instead of boto3's default `True`.
+    # Note: cacert must be used to pass the certificate; don't use verify for that; cf.
+    # https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html#ssl-settings
+    if cfg.get("insecure") or not cfg.get("verify", True):
         verify = False
     else:
-        verify = cfg.get("cacert") or cfg.get("verify")
+        verify = cfg.get("cacert")
     return boto3.resource(
         's3', endpoint_url=creds["HOST"], verify=verify,
         aws_access_key_id=creds["AK"], aws_secret_access_key=creds["SK"],

--- a/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
+++ b/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
@@ -31,8 +31,8 @@ def s3_conn(creds, conn):
     cfg = conn.config.config
     # Take insecure/verify/cacert parameter from clouds.yaml and pass it to boto3.resource.
     # If verify is True in clouds.yaml, fall back to cacert or None. In the latter case,
-    # the default boto3 behavior is applied (e.g., REQUESTS_CA_BUNDLE can still be used);
-    # but for that, verify must be `None` instead of boto3's default `True`.
+    # the default boto3 behavior is applied (where REQUESTS_CA_BUNDLE can still be used,
+    # and otherwise, boto3 defaults to verify=True).
     # Note: cacert must be used to pass the certificate; don't use verify for that; cf.
     # https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html#ssl-settings
     if cfg.get("insecure") or not cfg.get("verify", True):

--- a/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
+++ b/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
@@ -28,13 +28,16 @@ def compute_scs_0123_service_presence(services_lookup, *names):
 
 def s3_conn(creds, conn):
     """Return an s3 client conn"""
-    insecure = conn.config.config.get("insecure")
-    verify = conn.config.config.get("verify")
-    cacert = conn.config.config.get("cacert")
-    vrfy = False if (insecure is True or verify is False) else \
-        (cacert or (verify if isinstance(verify, str) else None))
+    cfg = conn.config.config
+    # Take insecure/verify/cacert parameter from clouds.yaml and pass it to boto3.resource.
+    # Deliberately do un-Pythonic `is True` and `is False` here because of type mayhem:
+    # for instance, handle verify=False differently from verify=None (or not set) or verify='some.ca'.
+    if cfg.get("insecure") is True or cfg.get("verify") is False:
+        verify = False
+    else:
+        verify = cfg.get("cacert") or cfg.get("verify")
     return boto3.resource(
-        's3', endpoint_url=creds["HOST"], verify=vrfy,
+        's3', endpoint_url=creds["HOST"], verify=verify,
         aws_access_key_id=creds["AK"], aws_secret_access_key=creds["SK"],
     )
 

--- a/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
+++ b/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
@@ -30,9 +30,9 @@ def s3_conn(creds, conn):
     """Return an s3 client conn"""
     cfg = conn.config.config
     # Take insecure/verify/cacert parameter from clouds.yaml and pass it to boto3.resource.
-    # If verify is True in clouds.yaml, fall back to cacert or None. In the latter case,
-    # the default boto3 behavior is applied (where REQUESTS_CA_BUNDLE can still be used,
-    # and otherwise, boto3 defaults to verify=True).
+    # If insecure is False/None and verify is True/None in clouds.yaml, fall back to cacert or None.
+    # In the latter case (None), the default boto3 behavior is applied (where config file or env
+    # variables can still be used, and otherwise, boto3 defaults to verify=True).
     # Note: cacert must be used to pass the certificate; don't use verify for that; cf.
     # https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html#ssl-settings
     if cfg.get("insecure") or not cfg.get("verify", True):


### PR DESCRIPTION
Take insecure/verify/cacert parameter from clouds.yaml and pass it to boto3.resource.
If insecure is True or verify is False use verify=False also for boto3.
Else, if you provide cacert(via cacert or verify parameter) it is also used for boto3.
If nothing from above is met, use verify=None to keep default boto3 behaviour.