### PR TITLE
rename FOCIS to Cloud&Heat IaaS

### DIFF
--- a/.zuul.d/secure.yaml
+++ b/.zuul.d/secure.yaml
@@ -101,7 +101,7 @@
           gY6QHocYpATL46iLkv97QANNUxTdxL7hQjdl/tf3TAHjCclmxdWhBJdvCJN/1xCM6EgVp
           NykBYxJ+kxSmkcFCSdUM8Td75bA/UzkPCdix1reJMdEAxTE9fC55XQ/liTLlGquQDnZty
           VLDH7x3ZJcxZsvqKR6vNbYYzJvDPTBYpHrhD7kx3ubyO9KX+SzZ+Dfhe9M8T8U=
-      focis_ac_id: !encrypted/pkcs1-oaep
+      cah-dd8a_ac_id: !encrypted/pkcs1-oaep
         - KB/tDE/a07eU+xtwor1iLxhvRdA/6bgkZn2aCPvkYtKKoVmT6sXpfRl1t319WqZRIRkoh
           GK0d9KMJkVT+Q5sbZiSxMD24yMBvwaImIBG6OCzxjyklqal1SOt6CLx4q/uGoGl7QrPOM
           WcRoluG1FCoDeUewgaZ50TQD0TQ8YGxuhRZi6s8KldDrYVkB/9HBUmwNhgd2LhExmNbtR
@@ -112,7 +112,7 @@
           YbdI4KBz6CcfrNdtut9XlmNLT91emT9ayC+XDqBypksHXHcypuqoOHMQUdjSPtXDLsI//
           dsSRxDL+4TtWaVovPAxaLGsiVohsoCEdAxBmYxbkA2DNYdOMf6glu7O4wMtEIjaBdzdfP
           CKfkOiwdCjtq++Ofn/C+3zI+2H+58TosQdCXcYIGmyKw5WSN7/sCosWDUtcsq4=
-      focis_ac_secret: !encrypted/pkcs1-oaep
+      cah-dd8a_ac_secret: !encrypted/pkcs1-oaep
         - E8fpHXVmMa7ptAndyV8fqgC6tmGL9qmtpI10q1Yh6Qo0iIt09HNl8aZLtupmavTqYJg+D
           7BI3ziTG4PNfc6MK0rvsQE/jGCf/XGW7yyfrmcvok+8mwD7foya5gEDLvbxFuIUopdTEt
           Wk+5qLHNv87fKtQVGoda1qZXQ2ZjEw3sLv5eENLEft+u3XZnPLMVJ3p9ZGK0mvBcIfAlk

--- a/.zuul.d/secure.yaml
+++ b/.zuul.d/secure.yaml
@@ -101,7 +101,7 @@
           gY6QHocYpATL46iLkv97QANNUxTdxL7hQjdl/tf3TAHjCclmxdWhBJdvCJN/1xCM6EgVp
           NykBYxJ+kxSmkcFCSdUM8Td75bA/UzkPCdix1reJMdEAxTE9fC55XQ/liTLlGquQDnZty
           VLDH7x3ZJcxZsvqKR6vNbYYzJvDPTBYpHrhD7kx3ubyO9KX+SzZ+Dfhe9M8T8U=
-      cah-dd8a_ac_id: !encrypted/pkcs1-oaep
+      cah_dd8a_ac_id: !encrypted/pkcs1-oaep
         - KB/tDE/a07eU+xtwor1iLxhvRdA/6bgkZn2aCPvkYtKKoVmT6sXpfRl1t319WqZRIRkoh
           GK0d9KMJkVT+Q5sbZiSxMD24yMBvwaImIBG6OCzxjyklqal1SOt6CLx4q/uGoGl7QrPOM
           WcRoluG1FCoDeUewgaZ50TQD0TQ8YGxuhRZi6s8KldDrYVkB/9HBUmwNhgd2LhExmNbtR

--- a/.zuul.d/secure.yaml
+++ b/.zuul.d/secure.yaml
@@ -112,7 +112,7 @@
           YbdI4KBz6CcfrNdtut9XlmNLT91emT9ayC+XDqBypksHXHcypuqoOHMQUdjSPtXDLsI//
           dsSRxDL+4TtWaVovPAxaLGsiVohsoCEdAxBmYxbkA2DNYdOMf6glu7O4wMtEIjaBdzdfP
           CKfkOiwdCjtq++Ofn/C+3zI+2H+58TosQdCXcYIGmyKw5WSN7/sCosWDUtcsq4=
-      cah-dd8a_ac_secret: !encrypted/pkcs1-oaep
+      cah_dd8a_ac_secret: !encrypted/pkcs1-oaep
         - E8fpHXVmMa7ptAndyV8fqgC6tmGL9qmtpI10q1Yh6Qo0iIt09HNl8aZLtupmavTqYJg+D
           7BI3ziTG4PNfc6MK0rvsQE/jGCf/XGW7yyfrmcvok+8mwD7foya5gEDLvbxFuIUopdTEt
           Wk+5qLHNv87fKtQVGoda1qZXQ2ZjEw3sLv5eENLEft+u3XZnPLMVJ3p9ZGK0mvBcIfAlk

--- a/Tests/config.toml
+++ b/Tests/config.toml
@@ -21,7 +21,7 @@ subjects = [
     "artcodix",
     "artcodix-ro",
     # currently not reachable from outside: "cc-rrze",
-    "focis",
+    "cah-dd8a",
     "pco-prod1",
     "pco-prod2",
     "pco-prod3",

--- a/compliance-monitor/bootstrap.yaml
+++ b/compliance-monitor/bootstrap.yaml
@@ -35,7 +35,7 @@ accounts:
       - public_key: "AAAAC3NzaC1lZDI1NTE5AAAAIF8kQx6ur/WSSY9ThK/mwhrl/VsYnjRk44GSXBy3VfKI"
         public_key_type: "ssh-ed25519"
         public_key_name: "primary"
-  - subject: focis
+  - subject: cah-dd8a
     delegates:
       - zuul_ci
     api_keys:

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -24,8 +24,8 @@ Version numbers are suffixed by a symbol depending on state: * for _draft_, † 
 | [CNDS](https://cnds.io/) | Public cloud for customers (2 regions) | artcodix GmbH |
 {#- #} [{{ results | pick(iaas, 'artcodix', 'artcodix-ro') | summary }}]({{ detail_url('group-artcodix', iaas) }}) {# -#}
 | [HM](https://ohm.muc.cloud.cnds.io/) |
-| FOCIS | ALASCA community environment for [FOCIS](https://alasca.cloud/focis/) | Cloud&amp;Heat Technologies GmbH |
-{#- #} [{{ results | pick(iaas, 'focis') | summary }}]({{ detail_url('focis', iaas) }}) {# -#}
+| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/produkte/cloud-services/infrastructure-as-a-service/) |Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
+{#- #} [{{ results | pick(iaas, 'cah-dd8a') | summary }}]({{ detail_url('cah-dd8a', iaas) }}) {# -#}
 | n/a |
 | [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 regions)  | plusserver GmbH | {# #}
 {#- #}[{{ results | pick(iaas, 'pco-prod1', 'pco-prod2', 'pco-prod3', 'pco-prod4') | summary }}]({{ detail_url('group-pco-prod', iaas) }}) {# -#}

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -24,7 +24,7 @@ Version numbers are suffixed by a symbol depending on state: * for _draft_, † 
 | [CNDS](https://cnds.io/) | Public cloud for customers (2 regions) | artcodix GmbH |
 {#- #} [{{ results | pick(iaas, 'artcodix', 'artcodix-ro') | summary }}]({{ detail_url('group-artcodix', iaas) }}) {# -#}
 | [HM](https://ohm.muc.cloud.cnds.io/) |
-| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/produkte/cloud-services/infrastructure-as-a-service/) |Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
+| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/en/products/cloud-services/infrastructure-as-a-service/) |Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
 {#- #} [{{ results | pick(iaas, 'cah-dd8a') | summary }}]({{ detail_url('cah-dd8a', iaas) }}) {# -#}
 | n/a |
 | [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 regions)  | plusserver GmbH | {# #}

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -24,7 +24,7 @@ Version numbers are suffixed by a symbol depending on state: * for _draft_, † 
 | [CNDS](https://cnds.io/) | Public cloud for customers (2 regions) | artcodix GmbH |
 {#- #} [{{ results | pick(iaas, 'artcodix', 'artcodix-ro') | summary }}]({{ detail_url('group-artcodix', iaas) }}) {# -#}
 | [HM](https://ohm.muc.cloud.cnds.io/) |
-| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/en/products/cloud-services/infrastructure-as-a-service/) |Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
+| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/en/products/cloud-services/infrastructure-as-a-service/) | Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
 {#- #} [{{ results | pick(iaas, 'cah-dd8a') | summary }}]({{ detail_url('cah-dd8a', iaas) }}) {# -#}
 | n/a |
 | [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 regions)  | plusserver GmbH | {# #}

--- a/playbooks/clouds.yaml.j2
+++ b/playbooks/clouds.yaml.j2
@@ -37,15 +37,15 @@ clouds:
       auth_url: https://api.cc.rrze.de:5000
       application_credential_id: "{{ clouds_conf.cc_rrze_ac_id }}"
       application_credential_secret: "{{ clouds_conf.cc_rrze_ac_secret }}"
-  focis:
+  cah-dd8a:
     region_name: "dd8a"
     interface: "public"
     identity_api_version: 3
     auth_type: "v3applicationcredential"
     auth:
       auth_url: https://identity.dd8a.cloudandheat.com:443/v3/
-      application_credential_id: "{{ clouds_conf.focis_ac_id }}"
-      application_credential_secret: "{{ clouds_conf.focis_ac_secret }}"
+      application_credential_id: "{{ clouds_conf.cah-dd8a_ac_id }}"
+      application_credential_secret: "{{ clouds_conf.cah-dd8a_ac_secret }}"
   pco-prod1:
     region_name: "prod1"
     interface: "public"

--- a/playbooks/clouds.yaml.j2
+++ b/playbooks/clouds.yaml.j2
@@ -44,8 +44,8 @@ clouds:
     auth_type: "v3applicationcredential"
     auth:
       auth_url: https://identity.dd8a.cloudandheat.com:443/v3/
-      application_credential_id: "{{ clouds_conf.cah-dd8a_ac_id }}"
-      application_credential_secret: "{{ clouds_conf.cah-dd8a_ac_secret }}"
+      application_credential_id: "{{ clouds_conf.cah_dd8a_ac_id }}"
+      application_credential_secret: "{{ clouds_conf.cah_dd8a_ac_secret }}"
   pco-prod1:
     region_name: "prod1"
     interface: "public"


### PR DESCRIPTION
This PR renames the existing "FOCIS" environment to "Cloud&Heat IaaS" in the compliance monitor. This new name emerged during the certification process of the Cloud&Heat public cloud according to SCS-0004.