### PR TITLE
add explanation before compliance result tables

### DIFF
--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -9,8 +9,10 @@ Version numbers are suffixed by a symbol depending on state: * for _draft_, † 
 
 ### SCS-compatible IaaS
 
+This is a list of IaaS clouds that we test on a nightly basis against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
+
 {% set iaas = '50393e6f-2ae1-4c5c-a62c-3b75f2abef3f' -%}
-| Name  | Description  | Operator  | [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/)  | HealthMon  |
+| Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
 |-------|--------------|-----------|----------------------|:----------:|
 | [scs2](https://docs.scs.community/community/cloud-resources/plusserver-gx-scs) | Dev/Test/Demo environment (2nd gen) provided for SCS & GAIA-X context | plusserver GmbH | 
 {#- #} [{{ results | pick(iaas, 'scs2') | summary }}]({{ detail_url('scs2', iaas) }}) {# -#}
@@ -48,8 +50,10 @@ Version numbers are suffixed by a symbol depending on state: * for _draft_, † 
 
 ### SCS-compatible KaaS
 
+This is a list of KaaS clouds that we test on a nightly basis against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
+
 {% set kaas = '1fffebe6-fd4b-44d3-a36c-fc58b4bb0180' -%}
-| Name  | Description  | Operator  | [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/)  |
+| Name  | Description  | Operator  | SCS-compatible KaaS  |
 |-------|--------------|-----------|----------------------|
 | [Noris](https://www.noris.de/) | KaaS offering based on Gardener | noris network AG | {# #}
 {#- #} [{{ results | pick(kaas, 'noris-1.33', 'noris-1.34') | summary }}]({{ detail_url('group-noris', kaas) }}) {# -#}


### PR DESCRIPTION
As we have now added KaaS to the certification overview, [the explanation (first sentence after heading) in the documentation is misleading](https://docs.scs.community/standards/certification/overview#:~:text=This%20is%20a%20list%20of%20clouds%20that%20we%20test%20on%20a%20nightly%20basis%20against%20the%20certificate%20scope%20SCS%2Dcompatible%20IaaS%2E). This PR moves the explanation (each adapted accordingly) to the respective tables.

Edit: Belonging PR in `docs` repo to actually remove the misleading explanation: SovereignCloudStack/docs#361