### PR TITLE
Handle Mergers & Acquisitions (M&A) in SCS-0007 integrator certification

### DIFF
--- a/Standards/scs-0007-v2-certification-integrators.md
+++ b/Standards/scs-0007-v2-certification-integrators.md
@@ -39,7 +39,7 @@ As to remain backward compatibility with version 1 of this standard, the suffix 
 
 ### General expectations
 
-The general expectation for certification is to provide proof of experience in setting up, operating and supporting SCS-compliant environments.
+The general expectation for certification is to provide proof of experience in setting up, operating and supporting SCS-compliant environments. This experience MUST remain in place for as long as the certification is valid.
 
 SCS is an open source community project with the goal of enabling digital sovereignty. As such, the commitment and support of this mission SHOULD be recognized and promoted beyond technical competence.
 


### PR DESCRIPTION
As [discussed in the SIG Std/Cert on 2026-04-23](https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20260423.md#how-to-handle-mergers--acquisitions), we want to handle Mergers & Acquisitions (M&A) in the context of the integrator certification (SCS-0007).

This PR addresses the short-term suggestion. The wording is intended to secure the continuation of the certified expertise in case of an M&A, but also in other situations.

This introduces a new "MUST" requirement, which usually means a new version for SCS-0007. However, since there is no certification based on V2 yet, I would refrain from doing so at this point. If not, we have to create a V3 draft. Until this becomes stable, however, it may take a while.