### PR TITLE
Introduce new `oldgeneric` os_purpose. Stabilize 0102-v2.

### DIFF
--- a/Standards/scs-0102-v2-image-metadata.md
+++ b/Standards/scs-0102-v2-image-metadata.md
@@ -1,7 +1,7 @@
 ---
 title: SCS Image Metadata
 type: Standard
-status: Stable
+status: Draft
 track: IaaS
 description: |
   This is version 2 of the SCS-0102 Image Metadata Standard.

--- a/Standards/scs-0102-v2-image-metadata.md
+++ b/Standards/scs-0102-v2-image-metadata.md
@@ -274,5 +274,4 @@ A boolean property that is not present is considered to be `false`.
   - Reference OpenStack image spec for standard values of `os_distro`, `architecture` and `hypervisor_type`.
   - Recommendation on `os_version` to be a version number (if such a value exists).
   - Recommended field `os_purpose`.
-- Version 2.0 makes the field `os_purpose` mandatory.
-- Version 2.1 added an `os_purpose` of `oldgeneric`.
+- Version 2.0 makes the field `os_purpose` mandatory and adds a new value `oldgeneric`.

--- a/Standards/scs-0102-v2-image-metadata.md
+++ b/Standards/scs-0102-v2-image-metadata.md
@@ -4,7 +4,7 @@ type: Standard
 status: Stable
 track: IaaS
 description: |
-  This is version 2.1 of the SCS-0102 Image Metadata Standard.
+  This is version 2 of the SCS-0102 Image Metadata Standard.
   It outlines how to categorize and manage metadata for cloud-based operating
   system images to ensure usability and clarity. The standard encompasses naming conventions, technical requirements,
   image handling protocols including updating and origin, and licensing/support details. These guidelines ensure

--- a/Standards/scs-0102-v2-image-metadata.md
+++ b/Standards/scs-0102-v2-image-metadata.md
@@ -1,10 +1,10 @@
 ---
 title: SCS Image Metadata
 type: Standard
-status: Draft
+status: Stable
 track: IaaS
 description: |
-  This is version 2 of the SCS-0102 Image Metadata Standard.
+  This is version 2.1 of the SCS-0102 Image Metadata Standard.
   It outlines how to categorize and manage metadata for cloud-based operating
   system images to ensure usability and clarity. The standard encompasses naming conventions, technical requirements,
   image handling protocols including updating and origin, and licensing/support details. These guidelines ensure
@@ -60,6 +60,7 @@ require an additional field:
   | `os_purpose` value | Intention                                                 |
   |--------------------|-----------------------------------------------------------|
   | `generic`          | A general purpose image, (mostly) vanilla from upstream   |
+  | `oldgeneric`       | A general purpose image, replaced by a newer one          |
   | `minimal`          | A much more barebones general purpose image               |
   | `k8snode`          | Node image built for k8s with CRI and kubelet             |
   | `gpu`              | Image with GPU drivers e.g. for HPC or AI                 |
@@ -70,8 +71,8 @@ require an additional field:
   of doubt. Talk to the SCS standardization bodies if you'd like to see this list extended which is
   likely the case if you fall back to `custom`.
 
-  The usage of standardized `os_distro`, `os_version`, `architecture`, and `os_purpose` help cloud users to create
-  automation that works across clouds without requiring image names to be standardized.
+  The usage of standardized `os_distro`, `os_version`, `architecture`, and `os_purpose` helps cloud users
+  to create automation that works across clouds without requiring image names to be standardized.
 
   _Uniqueness requirement_: For every assignment of values for `os_distro`, `os_version`,
   and `architecture`, there MUST be at most one public (`visibility=public`),
@@ -110,7 +111,9 @@ level).
 Technically, the thus updated image is a new image and will thus carry a new UUID.
 It is recommended that the old image gets renamed (e.g. build date or patch level attached)
 and hidden (`os_hidden=True`), but remains accessible via its (unchanged) UUID for some
-time.
+time. If an old image with `os_purpose` setting of `generic` is kept that way, we recommend
+to change `os_purpose` to `oldgeneric`. If it is not hidden, this is mandatory to meet
+the uniqueness requirement.
 
 The update handling by the provider is described via the properties `replace_frequency`,
 `uuid_validity`, `provided_until`, and `hotfix_hours`.
@@ -271,4 +274,5 @@ A boolean property that is not present is considered to be `false`.
   - Reference OpenStack image spec for standard values of `os_distro`, `architecture` and `hypervisor_type`.
   - Recommendation on `os_version` to be a version number (if such a value exists).
   - Recommended field `os_purpose`.
-- Version 2.0 (this one) makes the field `os_purpose` mandatory.
+- Version 2.0 makes the field `os_purpose` mandatory.
+- Version 2.1 added an `os_purpose` of `oldgeneric`.

--- a/Tests/iaas/scs_0102_image_metadata/image_metadata.py
+++ b/Tests/iaas/scs_0102_image_metadata/image_metadata.py
@@ -12,7 +12,7 @@ ARCHITECTURES = ("x86_64", "aarch64", "risc-v")
 HW_DISK_BUSES = ("virtio", "scsi", None)  # FIXME why None?
 HYPERVISOR_TYPES = ("qemu", "kvm", "xen", "hyper-v", "esxi", None)
 HW_RNG_MODELS = ("virtio", None)
-OS_PURPOSES = ("generic", "minimal", "k8snode", "gpu", "network", "custom")
+OS_PURPOSES = ("generic", "oldgeneric", "minimal", "k8snode", "gpu", "network", "custom")
 # Auxiliary mapping for `freq2secs` (note that values are rounded up a bit on purpose)
 FREQ_TO_SEC = {
     "never": 0,


### PR DESCRIPTION
As discussed on SIG Std/Cert on 2026-05-07.

This PR does three things:
- Introduce a new os_purpose oldgeneric. As only the generic images have the uniqueness requirements, we don't need a catch-all "old" nor do we need oldXXXX at this point.
- By consequence, change the standard to v2.1.
- Stabilize it.