### PR TITLE
Fix db bootstrap logic

### DIFF
--- a/compliance-monitor/sql.py
+++ b/compliance-monitor/sql.py
@@ -194,14 +194,13 @@ def db_upgrade_schema(conn: connection, cur: cursor):
     # that way just in case we want to use another database at some point
     while True:
         current = db_get_schema_version(cur)
-        if current >= SCHEMA_VERSIONS[-1]:  # bail if version is too new (but hope it's compatible)
-            break
         if current is None:
             # this is an empty db, but it also used to be the case with v1
             # I (mbuechse) made sure manually that the value v1 is set on running installations
             db_ensure_schema_v4(cur)
             db_set_schema_version(cur, 'v4')
             conn.commit()
+            break  # Nothing more to do, we bootstrapped with the latest schema version
         elif current == 'v1':
             db_ensure_schema_v2(cur)
             db_upgrade_data_v1_v2(cur)
@@ -219,6 +218,8 @@ def db_upgrade_schema(conn: connection, cur: cursor):
             db_ensure_schema_v4(cur)
             db_set_schema_version(cur, 'v4')
             conn.commit()
+        elif current >= SCHEMA_VERSIONS[-1]:  # bail if version is too new (but hope it's compatible)
+            break
 
 
 def db_ensure_schema(conn: connection):


### PR DESCRIPTION
An empty db has a current version of 'None', so we have to make sure to check for that first and leave the loop before encountering the '>=' comparison to avoid a TypeError.