### PR TITLE
Defuse scs-0123-swift-s3

### DIFF
--- a/Standards/scs-0123-v1-mandatory-and-supported-IaaS-services.md
+++ b/Standards/scs-0123-v1-mandatory-and-supported-IaaS-services.md
@@ -79,4 +79,3 @@ The SCS standard offers no guarantees for compatibility or reliability of servic
 ## Conformance Tests
 
 The presence of the mandatory OpenStack APIs will be tested in [this test-script](https://github.com/SovereignCloudStack/standards/blob/main/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py)
-The test will further check whether the object-store endpoint is compatible to s3.

--- a/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
+++ b/Standards/scs-0123-w1-mandatory-and-supported-IaaS-services-implementation.md
@@ -15,8 +15,9 @@ the following testcases in accordance with the standard:
 - `scs-0123-service-<type>` ensures that a service with the given type can be found in the service catalog
 - `scs-0123-storage-apis` ensures that a service of one of the following types can be found: "volume", "volumev3", "block-storage"
 
-### Deprecated tests
+v1 only (soon to be deprecated):
 
-#### v1 only
+- `scs-0123-swift-s3` ensures that S3 is present on the same host as swift
 
-- `scs-0123-swift-s3` ensures that S3 can be used to access object storage using EC2 credentials from the identity API
+Note: this testcase is a rather weak surrogate for testing the presence of S3 in general, which is resolved with v2,
+where a dedicated entry in the service catalog is mandated.

--- a/Tests/iaas/CHANGELOG
+++ b/Tests/iaas/CHANGELOG
@@ -1,0 +1,7 @@
+# IaaS test changelog
+
+## 2026-06-11
+
+- Relaxed `scs-0123-swift-s3`:
+  no longer access S3 via EC2 credentials from Keystone;
+  rather, only check that the S3 API is present.

--- a/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
+++ b/Tests/iaas/scs_0123_mandatory_services/mandatory_services.py
@@ -1,14 +1,11 @@
-import json
 import logging
 import re
-import uuid
 
 import boto3
 import openstack
 
 
-TESTCONTNAME = "scs-test-container"
-EC2MARKER = "TmpMandSvcTest"
+HOST_REGEX = re.compile(r"^(https*://[^/]*)/")
 
 logger = logging.getLogger(__name__)
 # NOTE suppress excessive logging (who knows what sensitive data might be in there)
@@ -45,131 +42,23 @@ def s3_conn(creds, conn):
     )
 
 
-def _parse_blob(cred):
-    try:
-        return json.loads(cred.blob)
-    except Exception as exc:
-        logger.debug(f"unable to parse credential {cred!r}: {exc!r}")
-        return None
-
-
-def get_usable_credentials(conn):
-    """
-    get all ec2 credentials for this project that carry meaningful data
-
-    returns list of pairs (credential, parsed ec2 data)
-    """
-    project_id = conn.identity.get_project_id()
-    candidates = [
-        (cred, _parse_blob(cred))
-        for cred in conn.identity.credentials()
-        if cred.type == "ec2" and cred.project_id == project_id
-    ]
-    return [
-        (cred, parsed)
-        for cred, parsed in candidates
-        if parsed and parsed.get('access') and parsed.get('secret')
-    ]
-
-
-def remove_leftovers(usable_credentials, conn):
-    """
-    makes sure to delete any leftover set of ec2 credentials
-    """
-    result = []
-    for item in usable_credentials:
-        cred, parsed = item
-        if parsed.get("owner") == EC2MARKER:
-            logger.debug(f"Removing leftover credential {parsed['access']}")
-            conn.identity.delete_credential(cred)
-        else:
-            result.append(item)
-    return result
-
-
-def ensure_ec2_credentials(usable_credentials, conn):
-    if usable_credentials:
-        return usable_credentials
-    parsed = {
-        "access": uuid.uuid4().hex,
-        "secret": uuid.uuid4().hex,
-        "owner": EC2MARKER,
-    }
-    blob = json.dumps(parsed)
-    try:
-        crd = conn.identity.create_credential(
-            type="ec2", blob=blob, user_id=conn.current_user_id, project_id=conn.current_project_id,
-        )
-    except BaseException:
-        logger.warning("ec2 creds creation failed", exc_info=True)
-        raise
-    usable_credentials.append((crd, parsed))
-    return usable_credentials  # also return for chaining
-
-
-def s3_from_ostack(usable_credentials, conn, rgx=re.compile(r"^(https*://[^/]*)/")):
-    """Set creds from openstack swift/keystone"""
-    # just use the first usable set of ec2 credentials
-    _, parsed = usable_credentials[0]
-    s3_creds = {
-        "AK": parsed["access"],
-        "SK": parsed["secret"],
-    }
-    m = rgx.match(conn.object_store.get_endpoint())
-    if m:
-        s3_creds["HOST"] = m.group(1)
-    return s3_creds
-
-
 def compute_scs_0123_swift_s3(services_lookup, conn: openstack.connection.Connection):
     """
-    This test ensures that S3 can be used to access object storage using EC2 credentials from the identity API.
+    This test ensures that S3 is present next to Swift.
     """
     if 'object-store' not in services_lookup:
         logger.info('skipping scs-0123-swift-s3 because object-store not present')
         return True
-    # we assume s3 is accessible via the service catalog, and Swift might exist too
-    usable_credentials = []
-    s3_buckets = []
-    # Get S3 endpoint (swift) and ec2 creds from OpenStack (keystone)
+    m = HOST_REGEX.match(conn.object_store.get_endpoint())
+    s3_creds = {
+        "AK": "doesnotexist",
+        "SK": "",
+        "HOST": m and m.group(1),
+    }
     try:
-        usable_credentials = remove_leftovers(get_usable_credentials(conn), conn)
-        # we could use any credential from the list usable_credentials, but let's not do that,
-        # because they could be stale
-        del usable_credentials[:]
-        s3_creds = s3_from_ostack(ensure_ec2_credentials(usable_credentials, conn), conn)
-
-        # This is to be used for local debugging purposes ONLY
-        # logger.debug(f"using credentials {s3_creds}")
-
-        s3 = s3_conn(s3_creds, conn)
-        buckets = list(s3.buckets.all())
-        if not buckets:
-            s3.create_bucket(Bucket=TESTCONTNAME)
-            buckets = list(s3.buckets.all())
-        if not buckets:
-            raise RuntimeError("failed to create S3 bucket")
-
-        # actual test: buckets must equal containers (sort in case the order is different)
-        s3_buckets = sorted([b.name for b in buckets])
-        sw_containers = sorted([c.name for c in conn.object_store.containers()])
-        if s3_buckets == sw_containers:
-            return True
-        logger.error(
-            "S3 buckets and Swift containers differ:\n"
-            f"S3: {s3_buckets}\n"
-            f"SW: {sw_containers}"
-        )
-        return False
-    finally:
-        # Cleanup created S3 bucket
-        if TESTCONTNAME in s3_buckets:
-            # contrary to Boto docs at
-            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/delete_bucket.html
-            # , the following fails with
-            # AttributeError: 's3.ServiceResource' object has no attribute 'delete_bucket'. Did you mean: 'create_bucket'?
-            # s3.delete_bucket(Bucket=TESTCONTNAME)
-            # workaround:
-            s3.Bucket(name=TESTCONTNAME).delete()
-        # Clean up ec2 cred IF we created one
-        remove_leftovers(usable_credentials, conn)
+        list(s3_conn(s3_creds, conn).buckets.all())
+    except Exception as error:
+        txt = str(error)
+        return "InvalidAccessKeyId" in txt or "NoSuchKey" in txt
+    else:
+        raise RuntimeError("this can not happen")

--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -481,6 +481,7 @@ modules:
       - scs-0123-service-load-balancer
       - scs-0123-service-placement
       - scs-0123-storage-apis
+      recommended:
       - scs-0123-swift-s3
   - id: scs-0123-v2
     name: Mandatory and Supported IaaS Services

--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -481,7 +481,6 @@ modules:
       - scs-0123-service-load-balancer
       - scs-0123-service-placement
       - scs-0123-storage-apis
-      recommended:
       - scs-0123-swift-s3
   - id: scs-0123-v2
     name: Mandatory and Supported IaaS Services


### PR DESCRIPTION
This testcase had multiple problems:

- It is not mentioned in the normative part of the standard (only in the section on testing)
- What user demand it is supposed to satisfy is unclear
- After recent updates to Keystone this no longer works with restricted (normal) application credentials

Its benefit (if any) does not outweigh its cost.

Downgraded to only test for presence of S3, but nothing in the way of functionality or consistency with Swift.