### PR TITLE
Simplify compliance monitor views

### DIFF
--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -501,6 +501,10 @@ modules:
       preview:
       - domain-manager-check
 timeline:
+  - date: 2026-06-11
+    versions:
+      next: draft
+      v5.1: effective
   - date: 2025-09-09
     versions:
       next: draft

--- a/Tests/scs_cert_lib.py
+++ b/Tests/scs_cert_lib.py
@@ -64,7 +64,7 @@ def _resolve_spec(spec: dict):
             id_ = testcase['id']
             if id_ in testcase_lookup:
                 raise RuntimeError(f"duplicate testcase {id_}")
-            testcase['attn'] = 0  # count: how many versions list this in target 'main'?
+            testcase['attn'] = 0  # count: how many stable versions list this in target 'main'?
             testcase_lookup[id_] = testcase
             tc_script_lookup[id_] = script
     module_lookup = {module['id']: module for module in spec['modules']}
@@ -97,8 +97,9 @@ def _resolve_spec(spec: dict):
         for target, tc_ids in targets.items():
             for tc_id in tc_ids:
                 tc_target[tc_id] = target
-        for tc_id in targets.get('main', ()):
-            testcase_lookup[tc_id]['attn'] += 1
+        if version.get('stabilized_at'):
+            for tc_id in targets.get('main', ()):
+                testcase_lookup[tc_id]['attn'] += 1
         version['targets'] = {target: sorted(tc_ids) for target, tc_ids in targets.items()}
         version['tc_target'] = tc_target
     # step 4b. resolve references to versions in timeline

--- a/compliance-monitor/monitor.py
+++ b/compliance-monitor/monitor.py
@@ -271,10 +271,11 @@ def _evaluate_scope(spec, scope_results, include_drafts=False):
     version_results = {
         vname: _evaluate_version(version, scope_results)
         for vname, version in versions.items()
+        if version['_explicit_validity']
     }
     by_validity = defaultdict(list)
     for vname, version in versions.items():
-        by_validity[version['validity']].append(vname)
+        by_validity[version['_explicit_validity']].append(vname)
     # go through worsening validity values until a passing version is found
     relevant = []
     best_passed = None

--- a/compliance-monitor/templates/details.md.j2
+++ b/compliance-monitor/templates/details.md.j2
@@ -1,7 +1,3 @@
-Testcase occurrences inside scope versions are marked
-"X" for required testcases (target _main_) and
-"(x)" for recommended testcases (with the specific target in the tooltip).
-
 Version numbers are suffixed by a symbol depending on state:
 \* for _draft_, † for _warn_ (soon to be deprecated), and †† for _deprecated_.
 
@@ -29,29 +25,22 @@ No recent test results available.
 
 {% else %}
 
-{% for cat, val in (('FAILED', -1), ('Aborted', 0), ('Missing', None), ('Passed', 1)) -%}
+The columns labeled _(rec)_ contain recommended testcases for the scope version named in the preceding column header.
+
+| testcase id | result |{% for version in scope_result.relevant %} {{ version }}{{ scope_result.versions[version].validity | validity_symbol }} | (rec) |{% endfor %} description |
+|---|---|{% for version in scope_result.relevant %}---|---|{% endfor %}---|
+{% for cat, val in (('FAILED', -1), ('MISSING', None), ('inconclusive', 0), ('passed', 1)) -%}
 {% set bucket = scope_result.buckets[val] -%}
-{% if bucket -%}
-### {{cat}} testcases
-
-{% if val == -1 %}Note: recommended testcases (marked "(x)") do not count into the
-overall result of a version.{% endif %}
-
-| testcase id |{% if val is not none %} reported on |{% endif %}{% for version in scope_result.relevant %} {{ version }}{{ scope_result.versions[version].validity | validity_symbol }} |{% endfor %} description |
-|---|{% if val is not none %}---|{% endif %}{% for version in scope_result.relevant %}---|{% endfor %}---|
 {% for testcase_id in bucket -%}
 {% set testcase = scope_result.testcases[testcase_id] -%}
 {% set res = scope_result.results[testcase_id] if testcase_id in scope_result.results else dict(result=0) -%}
 | [{{ testcase_id }}]({{ testcase.url }}) {# -#}
-{%- if val is not none -%}
-| {% if res.report %}[{{ res.checked_at | short_isodate }}]({{ report_url(res.report, version, testcase_id) }}) { title="{{ res.report }} {{ res.checked_at }}" }{% endif %} {# -#}
-{%- endif %}{# val is not none -#}
+| {{cat}}{% if res.report %} ([{{ res.checked_at | short_isodate }}]({{ report_url(res.report, version, testcase_id) }})) { title="{{ res.report }} {{ res.checked_at }}" }{% endif %} {# -#}
 {% for version in scope_result.relevant %}| {%
 set tgt = scope_result.versions[version].tc_target[testcase_id]
-%}{% if tgt == 'main' %}X { title="main" }{% elif tgt %}(x) { title="{{ tgt }}" }{% endif %} {% endfor -%}
+%}{% if tgt == 'main' %}X { title="main" }{% endif %} | {% if tgt and tgt != 'main' %}x { title="{{ tgt }}" }{% endif %} {% endfor -%}
 | {{ testcase.description | trim }} |
-{% endfor %}{# testcase #}
-{% endif %}{# bucket nonempty -#}
+{% endfor %}{# testcase -#}
 {% endfor %}{# categories #}
 
 {% endif %}{# results available -#}

--- a/compliance-monitor/templates/details.md.j2
+++ b/compliance-monitor/templates/details.md.j2
@@ -29,13 +29,18 @@ The columns labeled _(rec)_ contain recommended testcases for the scope version 
 
 | testcase id | result |{% for version in scope_result.relevant %} {{ version }}{{ scope_result.versions[version].validity | validity_symbol }} | (rec) |{% endfor %} description |
 |---|---|{% for version in scope_result.relevant %}---|---|{% endfor %}---|
-{% for cat, val in (('FAILED', -1), ('MISSING', None), ('inconclusive', 0), ('passed', 1)) -%}
+{% for cat, sym0, val in (('FAILED', '🛑🟧', -1), ('MISSING', '❓', None), ('inconclusive', '❔', 0), ('passed', '✅', 1)) -%}
 {% set bucket = scope_result.buckets[val] -%}
 {% for testcase_id in bucket -%}
 {% set testcase = scope_result.testcases[testcase_id] -%}
 {% set res = scope_result.results[testcase_id] if testcase_id in scope_result.results else dict(result=0) -%}
 | [{{ testcase_id }}]({{ testcase.url }}) {# -#}
-| {{cat}}{% if res.report %} ([{{ res.checked_at | short_isodate }}]({{ report_url(res.report, version, testcase_id) }})) { title="{{ res.report }} {{ res.checked_at }}" }{% endif %} {# -#}
+{% if val == -1 -%}
+{% if testcase.attn %}{% set sym = sym0[0:1] %}{% else %}{% set sym = sym0[1:2] %}{% endif -%}
+{% else -%}
+{% set sym = sym0 -%}
+{% endif -%}
+| {{sym}} {{cat}}{% if res.report %} ([{{ res.checked_at | short_isodate }}]({{ report_url(res.report, version, testcase_id) }})) { title="{{ res.report }} {{ res.checked_at }}" }{% endif %} {# -#}
 {% for version in scope_result.relevant %}| {%
 set tgt = scope_result.versions[version].tc_target[testcase_id]
 %}{% if tgt == 'main' %}X { title="main" }{% endif %} | {% if tgt and tgt != 'main' %}x { title="{{ tgt }}" }{% endif %} {% endfor -%}

--- a/compliance-monitor/templates/details.md.j2
+++ b/compliance-monitor/templates/details.md.j2
@@ -29,7 +29,7 @@ The columns labeled _(rec)_ contain recommended testcases for the scope version 
 
 | testcase id | result |{% for version in scope_result.relevant %} {{ version }}{{ scope_result.versions[version].validity | validity_symbol }} | (rec) |{% endfor %} description |
 |---|---|{% for version in scope_result.relevant %}---|---|{% endfor %}---|
-{% for cat, sym0, val in (('FAILED', '🛑🟧', -1), ('MISSING', '❓', None), ('inconclusive', '❔', 0), ('passed', '✅', 1)) -%}
+{% for cat, sym0, val in (('FAIL', '🛑🟧', -1), ('MISSING', '❓', None), ('DNF', '❔', 0), ('pass', '✅', 1)) -%}
 {% set bucket = scope_result.buckets[val] -%}
 {% for testcase_id in bucket -%}
 {% set testcase = scope_result.testcases[testcase_id] -%}


### PR DESCRIPTION
- Remove deprecated scope versions, because they are only achieved by accident (no one is actively working on supporting them), and they make the views (even) more complicated.
- Restructure details view a bit.