### PR TITLE
Increase number of workers in preset 'iaas' from 4 to 16

### DIFF
--- a/Tests/config.toml
+++ b/Tests/config.toml
@@ -32,7 +32,7 @@ subjects = [
     "syseleven-ham1",
     "wavestack",
 ]
-workers = 4
+workers = 16
 
 
 [presets.kaas]


### PR DESCRIPTION
These workers don't use a lot of resources except wall time