### PR TITLE
Refresh scaleup_api_server secret.

### DIFF
--- a/.zuul.d/secure.yaml
+++ b/.zuul.d/secure.yaml
@@ -458,16 +458,16 @@
           /Lt6+yMJMB7AUVpwXkI7cMmf+QXbDnnE6eX0UBosTM6MjdA/zhkjJ6PK9E0FnngW4HRDZ
           eAiVSQiN4CSa9bylrwLhvarAEhR+5avRv4yTurgAYe6I6Gh05pBPCgTXmCNxPU=
       scaleup_api_server: !encrypted/pkcs1-oaep
-        - H4F/zi6Lp/CbkHPG4tEzhFVRprH6uxVqoOirUZNKOg1pDI33ilXG4K99O/CH9dCqbFiV0
-          GnI4p8b0Csho6S63DEuMikjXBLfNWsd2BncQ4gu4bGhHef3bkCjEmybk3AmEyA789vRNS
-          o6xjZUAJB0ZEQeuWudSo28fJDGxGOVcVW0Sda+OSk0K3qftucg047KZdJ5bWZmHTPvOha
-          4R2+nsbnecAQJtMDWVERPYTD62pF4CAHD6XVf9mUuZNnLYibl5uQz0t6JZQANu83pFYDZ
-          C5Z7T4/UJxKlyBpL2XtF/cHuKavEP41cheD/ihG1EI9Yf3InFCRllbIGzMj8fq8d4bZKV
-          tC1iui2RrL3s38GrOyyGE7odyHlvl08zbrJTkWb5UcI20jPxBCxHAvlqIWjl+9Ite7OuM
-          nXq62IgXUqVWWgrGWRINyJlvRgcQPxCVq7ty3OMB1Vp4R0ldDRWWR9+PozmK86fRXYatE
-          cgRi579JMBvKjbP9hKcZOkb12PVyZTTOLmyepfMAqZVpBULtpNza26ysCl5Wu14+0o3bh
-          d6Kst5qeZz4P8QjJe2UQU67B8JcX88zbpNYM1uxLhtXlAk0/8Hd8KWm+KiU/NfNzgr7jd
-          jxRhMEdHUuMOKHaSR/hwJs7kWp1RVR6l7L+SXv02VrYgzysGCiGqXhV9FwrEQw=
+        - VCeER+5TfxyzOnvIWrAx30FRdwa4I837hPnELGWWmmzdyPQCKVqP4dKEX09nmzwabLnWF
+          WEzMhG9tHsIPBImP2x6VMAqwGsocAdS+Xw73gJXJm0P79gc2xqbnL8BpirraAH+TpCG+G
+          eYcQKzfKfhIViVix7WJfeqodN6sB3oaAodlcvjMpqeYL+USQsZj+ejZZc61P0ec8AybXd
+          lCxuRrdutks6aJlnIaQ9o1G+40DUzljd6RrrGQDPfQOx8XZCaN+eskpox/iKVX6Fso23U
+          Zv8ZCQg2FsT9M9s2GC/KcLgQcHVIkKTYpr6Fnx4ymoxfCE4D2l2B6hK6PcT8I4OAMDZKn
+          MtV8wSsSbnohUpCGN8qMyjTf5q2WHr55BWaYmvRVkAwm+eAEd2/EBr6FSXss9C0hKNznr
+          w60LZhXC5QCXvc3tS+A+8s913luzQI8zmlQCSHHqIJujtLNhP/BO/7EpR9GMHD9KZxP17
+          IqElVTiWYJX2tzx309+G4zhw5L8qwG9FvaDVr9DBdv1mgrKl7QTi5SbfQMn4DExCCaJmR
+          kglEjdtYoHoulJP0KD9a1Sfrg0sQDPBag44cjORfN8mvzPcI2QLAz+iClZhi2pHVnwEZH
+          k49ZE1+gp/PUdlFPDdhHVAJgB4tzZEXPOrbgUGCIqqNam9IwzOrRuFR8fIvXVo=
       scaleup_ca_data: !encrypted/pkcs1-oaep
         - CDar1TQ3Q4HrBXIDwVFvzL0FgPFy7r3K4joQmKnIbCJZ9pmbtrGGSD7xOsJnfIm5e89ZK
           g4D654VfvK4+upredcVP5MRkfXY/SKfh9glR9okQMpsRS0T5l3kS+RpZOLPCuvvit3i1h


### PR DESCRIPTION
It's not a secret secret, so this is uncritical.
We use it as a canary since #1190.
As the webhook was broken before, we would not run the check and post pipelines on it. We should now do so, so refresh the secret.