### PR TITLE
Add k8s branch 1.35 to tests

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -6,7 +6,9 @@
     periodic-daily:
       jobs:
         - scs-check-iaas
-        - scs-check-kaas
+        - scs-check-kaas1
+        - scs-check-kaas2
+        - scs-check-kaas3
     periodic-hourly:
       jobs:
         - scs-check-scs2-main

--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -59,7 +59,7 @@
     vars:
       preset: iaas
 - job:
-    name: scs-check-kaas
+    name: scs-check-kaas1
     parent: scs-check-scs2-main
     # timeout:
     # a) these tests take a lot of time, I'm afraid, particularly Sonobuoy
@@ -67,9 +67,17 @@
     timeout: 21600  # 6 hrs -- 5 hrs was almost sufficient (reports came through sometimes)
     attempts: 1  # this job is heavy, and retries aren't very promising
     vars:
-      preset: kaas
+      preset: kaas1
       iaas: false
       kaas: true
       section: '.auto'  # only do 'heavy' tests on Saturdays
       do_provision: true
       do_cleanup: false
+    name: scs-check-kaas2
+    parent: scs-check-kaas1
+    vars:
+      preset: kaas2
+    name: scs-check-kaas3
+    parent: scs-check-kaas1
+    vars:
+      preset: kaas3

--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -73,10 +73,12 @@
       section: '.auto'  # only do 'heavy' tests on Saturdays
       do_provision: true
       do_cleanup: false
+- job:
     name: scs-check-kaas2
     parent: scs-check-kaas1
     vars:
       preset: kaas2
+- job:
     name: scs-check-kaas3
     parent: scs-check-kaas1
     vars:

--- a/Tests/config.toml
+++ b/Tests/config.toml
@@ -40,11 +40,51 @@ scopes = [
     "scs-compatible-kaas",
 ]
 subjects = [
+    "noris-1.33",
     "noris-1.34",
+    "noris-1.35",
     "scaleup-1.33",
     "scaleup-1.34",
+    "scaleup-1.35",
     "syself-1.33",
     "syself-1.34",
+    "syself-1.35",
+]
+workers = 16
+
+
+[presets.kaas1]
+scopes = [
+    "scs-compatible-kaas",
+]
+subjects = [
+    "noris-1.33",
+    "scaleup-1.33",
+    "syself-1.33",
+]
+workers = 4
+
+
+[presets.kaas2]
+scopes = [
+    "scs-compatible-kaas",
+]
+subjects = [
+    "noris-1.34",
+    "scaleup-1.34",
+    "syself-1.34",
+]
+workers = 4
+
+
+[presets.kaas3]
+scopes = [
+    "scs-compatible-kaas",
+]
+subjects = [
+    "noris-1.35",
+    "scaleup-1.35",
+    "syself-1.35",
 ]
 workers = 4
 

--- a/Tests/kaas/plugin/plugin_gardener.py
+++ b/Tests/kaas/plugin/plugin_gardener.py
@@ -164,8 +164,10 @@ class PluginGardener(KubernetesClusterPlugin):
     def _render_template(self, key):
         return self.template_map[key].render(**self.vars, **self.secrets)
 
-    def _auto_vars_noris(self, api_instance: _gh.CustomObjectsApi):
-        logging.debug('using autoVars/noris')
+    def _auto_vars_noris(self, api_instance: _gh.CustomObjectsApi, alias: str):
+        # this was introduced for use with noris Sovereign Cloud, but it works for others as well,
+        # and to reduce potential for confusion, allow aliases (such as autoVars/scaleup)
+        logging.debug(f'using autoVars/{alias}')
         cloud_profile = _gh.get_cloudprofile(api_instance, self.namespace, self.vars['cloud_profile_name'])
         version_items = cloud_profile['spec']['kubernetes']['versions']
         # filter by kubernetesVersion and classification==supported
@@ -178,7 +180,7 @@ class PluginGardener(KubernetesClusterPlugin):
         ]
         logging.debug(f'matching k8s versions: {versions}')
         if not versions:
-            raise RuntimeError(f'autoVars/noris failed: no versions found for v{version_prefix}x')
+            raise RuntimeError(f'autoVars/{alias} failed: no versions found for v{version_prefix}x')
         # select latest patch version (assume patch part is numeric)
         selected_version = max(versions, key=lambda ver: int(ver.rsplit('.', 1)[-1]))
         return {'kubernetes_version': selected_version}
@@ -189,8 +191,8 @@ class PluginGardener(KubernetesClusterPlugin):
         # now on to specifics
         if not auto_vars_kind:
             return
-        if auto_vars_kind == 'noris':
-            auto_vars = self._auto_vars_noris(co_api)
+        if auto_vars_kind in ('noris', 'scaleup'):
+            auto_vars = self._auto_vars_noris(co_api, alias=auto_vars_kind)
         else:
             raise RuntimeError(f'unknown kind of autoVars: {auto_vars_kind}')
         logger.debug(f'applying autoVars/{auto_vars_kind}: {auto_vars}')

--- a/compliance-monitor/bootstrap.yaml
+++ b/compliance-monitor/bootstrap.yaml
@@ -100,6 +100,10 @@ accounts:
     group: noris
     delegates:
       - zuul_ci
+  - subject: noris-1.35
+    group: noris
+    delegates:
+      - zuul_ci
   - subject: scaleup-1.33
     group: scaleup
     delegates:
@@ -108,11 +112,19 @@ accounts:
     group: scaleup
     delegates:
       - zuul_ci
+  - subject: scaleup-1.35
+    group: scaleup
+    delegates:
+      - zuul_ci
   - subject: syself-1.33
     group: syself
     delegates:
       - zuul_ci
   - subject: syself-1.34
+    group: syself
+    delegates:
+      - zuul_ci
+  - subject: syself-1.35
     group: syself
     delegates:
       - zuul_ci

--- a/playbooks/.config/scs/shoot.yaml
+++ b/playbooks/.config/scs/shoot.yaml
@@ -41,11 +41,6 @@ spec:
   credentialsBindingName: {{ credentials_binding_name }}
   purpose: evaluation
   region: {{ region }}
-  addons:
-    kubernetesDashboard:
-      enabled: false
-    nginxIngress:
-      enabled: false
   maintenance:
     autoUpdate:
       kubernetesVersion: true

--- a/playbooks/clusters.yaml.j2
+++ b/playbooks/clusters.yaml.j2
@@ -56,6 +56,33 @@ clusters:
         garden_api_server: "{{ clouds_conf.noris_api_server }}"
         garden_ca_data: "{{ clouds_conf.noris_ca_data }}"
         garden_token: "{{ clouds_conf.noris_token }}"
+  noris-1.35:
+    kind: gardener
+    config:
+      name: 'noris-1-35'  # explicit name because dot in name not permissible
+      kubernetesVersion: '1.35'
+      autoVars: noris  # determine vars.kubernetes_version automatically using kubernetesVersion
+      templates:
+        shoot: shoot.yaml
+        kubeconfig: garden-kubeconfig.yaml
+      vars:
+        num_worker_nodes: 3
+        worker_cidr: "10.250.0.0/16"
+        machine_type: "SCS-1V-16-50"
+        machine_image_name: "flatcar"
+        machine_image_version: "4081.3.6"
+        networking_type: cilium
+        region: "nsc-nbg"
+        zone: "nbg1"
+        floating_pool_name: "external"
+        load_balancer_provider: "ovn"
+        cloud_profile_name: "openstack"
+        credentials_binding_name: "default-openstack-secret"
+        garden_namespace: "garden-nkhv1db5ym"
+      secrets:
+        garden_api_server: "{{ clouds_conf.noris_api_server }}"
+        garden_ca_data: "{{ clouds_conf.noris_ca_data }}"
+        garden_token: "{{ clouds_conf.noris_token }}"
   scaleup-1.33:
     kind: gardener
     config:
@@ -110,18 +137,45 @@ clusters:
         garden_api_server: "{{ clouds_conf.scaleup_api_server }}"
         garden_ca_data: "{{ clouds_conf.scaleup_ca_data }}"
         garden_token: "{{ clouds_conf.scaleup_token }}"
-  syself-1.32:
+  scaleup-1.35:
+    kind: gardener
+    config:
+      name: 'scaleup-1-35'  # explicit name because dot in name not permissible
+      kubernetesVersion: '1.35'
+      autoVars: noris  # determine vars.kubernetes_version automatically using kubernetesVersion; noris works well for us
+      templates:
+        shoot: shoot.yaml
+        kubeconfig: garden-kubeconfig.yaml
+      vars:
+        num_worker_nodes: 3
+        worker_cidr: "10.250.0.0/16"
+        machine_type: "SCS-2V-4-40p"
+        machine_image_name: "gardenlinux"
+        machine_image_version: "1877.17.0"
+        networking_type: calico
+        region: "RegionOne"
+        zone: "az1"
+        floating_pool_name: "external"
+        load_balancer_provider: "ovn"
+        cloud_profile_name: "occ2"
+        credentials_binding_name: "c70012-14"
+        garden_namespace: "garden-c70012-14"
+      secrets:
+        garden_api_server: "{{ clouds_conf.scaleup_api_server }}"
+        garden_ca_data: "{{ clouds_conf.scaleup_ca_data }}"
+        garden_token: "{{ clouds_conf.scaleup_token }}"
+  syself-1.35:
     kind: clusterstacks
     config:
-      kubernetesVersion: '1.32'
-      name: 'syself-1-32'  # explicit name because dot in name not permissible
+      kubernetesVersion: '1.35'
+      name: 'syself-1-35'  # explicit name because dot in name not permissible
       autoVars: syself  # determine cs_class_name and cs_version automatically using kubernetesVersion
       templates:
         cluster: syself-cluster.yaml
         clusterstack: syself-clusterstack.yaml
         kubeconfig: syself-kubeconfig.yaml
       vars:
-        cs_name: hetzner-apalla-1-32
+        cs_name: hetzner-apalla-1-35
         num_control_nodes: 3
         num_worker_nodes: 3
       secrets:

--- a/playbooks/clusters.yaml.j2
+++ b/playbooks/clusters.yaml.j2
@@ -88,7 +88,7 @@ clusters:
     config:
       name: 'scaleup-1-33'  # explicit name because dot in name not permissible
       kubernetesVersion: '1.33'
-      autoVars: noris  # determine vars.kubernetes_version automatically using kubernetesVersion; noris works well for us
+      autoVars: scaleup  # determine vars.kubernetes_version automatically using kubernetesVersion
       templates:
         shoot: shoot.yaml
         kubeconfig: garden-kubeconfig.yaml
@@ -115,7 +115,7 @@ clusters:
     config:
       name: 'scaleup-1-34'  # explicit name because dot in name not permissible
       kubernetesVersion: '1.34'
-      autoVars: noris  # determine vars.kubernetes_version automatically using kubernetesVersion; noris works well for us
+      autoVars: scaleup  # determine vars.kubernetes_version automatically using kubernetesVersion
       templates:
         shoot: shoot.yaml
         kubeconfig: garden-kubeconfig.yaml
@@ -142,7 +142,7 @@ clusters:
     config:
       name: 'scaleup-1-35'  # explicit name because dot in name not permissible
       kubernetesVersion: '1.35'
-      autoVars: noris  # determine vars.kubernetes_version automatically using kubernetesVersion; noris works well for us
+      autoVars: scaleup  # determine vars.kubernetes_version automatically using kubernetesVersion
       templates:
         shoot: shoot.yaml
         kubeconfig: garden-kubeconfig.yaml


### PR DESCRIPTION
This includes two improvements:

- test the k8s branches sequentially to avoid hitting quotas
- introduce alias 'autoVars/scaleup' for 'autoVars/noris' to reduce potential for confusion