### PR TITLE
Fix missing testcase scs-0114-syntax-check

### DIFF
--- a/Tests/scs-compatible-iaas.yaml
+++ b/Tests/scs-compatible-iaas.yaml
@@ -227,6 +227,9 @@ scripts:
   - id: scs-0104-image-debian-12
     description: Debian 12 image is present (by name).
     url: https://docs.scs.community/standards/scs-0104-w1-standard-images-implementation#automated-tests
+  - id: scs-0114-syntax-check
+    description: Aspect list in volume type description, if present, is formatted according to the standard.
+    url: https://docs.scs.community/standards/scs-0114-w1-volume-type-implementation#automated-tests
   - id: scs-0114-encrypted-type
     description: An encrypted volume type can be discovered.
     url: https://docs.scs.community/standards/scs-0114-w1-volume-type-implementation#automated-tests
@@ -438,6 +441,8 @@ modules:
     name: Volume Types
     url: https://docs.scs.community/standards/scs-0114-v1-volume-type-standard
     targets:
+      main:
+      - scs-0114-syntax-check
       recommended:
       - scs-0114-encrypted-type
       - scs-0114-replicated-type


### PR DESCRIPTION
The only requirement of the volume type standard was missing.