### PR TITLE
Run at most one kaas job at one time, same for iaas

### DIFF
--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -31,14 +31,12 @@
     pre-run: playbooks/pre.yaml
     run: playbooks/adr_syntax.yaml
 - job:
-    name: scs-check-scs2
+    name: scs-check-base
     parent: base
     secrets:
      - name: clouds_conf
        secret: SECRET_STANDARDS
     nodeset: pod-fedora-40
-    semaphores:
-      - semaphore-iaas
     vars:
       preset: default
       iaas: true
@@ -55,6 +53,11 @@
     post-run:
      - playbooks/post_cloud.yaml
 - job:
+    name: scs-check-scs2
+    parent: scs-check-base
+    semaphores:
+      - semaphore-iaas
+- job:
     name: scs-check-scs2-main
     parent: scs-check-scs2
     branches: main
@@ -70,8 +73,9 @@
       preset: iaas
 - job:
     name: scs-check-kaas1
-    parent: scs-check-scs2-main
-    semaphores: !override
+    parent: scs-check-base
+    branches: main
+    semaphores:
       - semaphore-kaas
     # timeout:
     # a) these tests take a lot of time, I'm afraid, particularly Sonobuoy

--- a/.zuul.d/config.yaml
+++ b/.zuul.d/config.yaml
@@ -18,6 +18,12 @@
     check:
       jobs:
         - scs-check-adr-syntax
+- semaphore:
+    name: semaphore-iaas
+    max: 1  # run at most one iaas job at the same time
+- semaphore:
+    name: semaphore-kaas
+    max: 1  # run at most one kaas job at the same time
 - job:
     name: scs-check-adr-syntax
     parent: base
@@ -31,6 +37,8 @@
      - name: clouds_conf
        secret: SECRET_STANDARDS
     nodeset: pod-fedora-40
+    semaphores:
+      - semaphore-iaas
     vars:
       preset: default
       iaas: true
@@ -63,6 +71,8 @@
 - job:
     name: scs-check-kaas1
     parent: scs-check-scs2-main
+    semaphores: !override
+      - semaphore-kaas
     # timeout:
     # a) these tests take a lot of time, I'm afraid, particularly Sonobuoy
     # b) keep in mind that this job covers ALL test subjects (at most 4 in parallel)


### PR DESCRIPTION
We want to run the tests for the k8s branches in sequence to avoid hitting quotas and to conserve resources.

For iaas, we want to avoid that the hourly job interferes with the daily job or (more likely and observed already) the post-merge job.