### PR TITLE
Fix false positive in scs-0101-fips-test

### DIFF
--- a/Tests/iaas/scs_0101_entropy/entropy_check.py
+++ b/Tests/iaas/scs_0101_entropy/entropy_check.py
@@ -127,28 +127,28 @@ def compute_scs_0101_rngd(collected_vm_output, image_name):
 def compute_scs_0101_fips_test(collected_vm_output, image_name):
     """This test ensures that the 'fips test' via `rngtest` is passed on a test VM."""
     lines = collected_vm_output['fips-test']
-    try:
-        fips_data = '\n'.join(lines)
-        failure_re = re.search(r'failures:\s\d+', fips_data, flags=re.MULTILINE)
-        if failure_re:
-            fips_failures = failure_re.string[failure_re.regs[0][0]:failure_re.regs[0][1]].split(" ")[1]
-            if int(fips_failures) <= 3:
-                return True  # strict test passed
-            logger.info(
-                f"VM '{image_name}' didn't pass the strict FIPS 140-2 testing. "
-                f"Expected a maximum of 3 failures, got {fips_failures}."
-            )
-            if int(fips_failures) <= 5:
-                return True  # lenient test passed
-            logger.error(
-                f"VM '{image_name}' didn't pass the FIPS 140-2 testing. "
-                f"Expected a maximum of 5 failures, got {fips_failures}."
-            )
-        else:
-            logger.error(f"VM '{image_name}': failed to determine fips failures")
-            logger.debug(f"stderr following:\n{fips_data}")
-    except BaseException:
-        logger.critical(f"Couldn't check VM '{image_name}' requirements", exc_info=True)
+    fips_data = '\n'.join(lines)
+    failure_re = re.search(r'failures:\s\d+', fips_data, flags=re.MULTILINE)
+    if not failure_re:
+        # It seems possible that 'failures: 0' is just omitted, and we could check for
+        # 'successes: 1000' to verify that, but I have observed this only once in many
+        # many runs over multiple years. I'm inclined to label this 'inconclusive'
+        # instead of making the code more complex and risking false certainty.
+        logger.debug(f"failed to determine fips failures; stderr following:\n{fips_data}")
+        raise RuntimeError(f"VM '{image_name}': failed to determine fips failures")
+    fips_failures = failure_re.string[failure_re.regs[0][0]:failure_re.regs[0][1]].split(" ")[1]
+    if int(fips_failures) <= 3:
+        return True  # strict test passed
+    logger.info(
+        f"VM '{image_name}' didn't pass the strict FIPS 140-2 testing. "
+        f"Expected a maximum of 3 failures, got {fips_failures}."
+    )
+    if int(fips_failures) <= 5:
+        return True  # lenient test passed
+    logger.error(
+        f"VM '{image_name}' didn't pass the FIPS 140-2 testing. "
+        f"Expected a maximum of 5 failures, got {fips_failures}."
+    )
     return False  # any unsuccessful path should end up here
 
 


### PR DESCRIPTION
[Observed](https://compliance.sovereignit.cloud/page/report_full/3f8acb02-4b0f-4b7b-8d3b-ede0f1837035#6a567f68-26e2-4cbf-b275-c5e6f7a28849) this for the first time ever:

```
ERROR: VM 'Debian 13': failed to determine fips failures
DEBUG: stderr following:
rngtest 5
Copyright (c) 2004 by Henrique de Moraes Holschuh
This is free software; see the source for copying conditions.  There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
rngtest: starting FIPS tests...
rngtest: bits received from input: 20000032
rngtest: FIPS 140-2 successes: 1000
rngtest: FIPS 140-2(2001-10-10) Monobit: 0
rngtest: FIPS 140-2(2001-10-10) Poker: 0
rngtest: FIPS 140-2(2001-10-10) Runs: 0
rngtest: FIPS 140-2(2001-10-10) Long run: 0
rngtest: FIPS 140-2(2001-10-10) Continuous run: 0
rngtest: input channel speed: (min=23.694; avg=2042.785; max=9536.743)Mibits/s
rngtest: FIPS tests speed: (min=96.331; avg=147.113; max=157.632)Mibits/s
rngtest: Program run time: 139869 microseconds
```

Notice: no line saying `rngtest: FIPS 140-2 failures:`
