### PR TITLE
Remove k8s-1.33 subjects (now EOL)

### DIFF
--- a/Tests/config.toml
+++ b/Tests/config.toml
@@ -40,13 +40,10 @@ scopes = [
     "scs-compatible-kaas",
 ]
 subjects = [
-    "noris-1.33",
     "noris-1.34",
     "noris-1.35",
-    "scaleup-1.33",
     "scaleup-1.34",
     "scaleup-1.35",
-    "syself-1.33",
     "syself-1.34",
     "syself-1.35",
 ]
@@ -58,9 +55,7 @@ scopes = [
     "scs-compatible-kaas",
 ]
 subjects = [
-    "noris-1.33",
-    "scaleup-1.33",
-    "syself-1.33",
+	# add 1.36 subjects here
 ]
 workers = 4
 

--- a/Tests/kaas/scs_0210_version_policy/k8s-eol-data.yml
+++ b/Tests/kaas/scs_0210_version_policy/k8s-eol-data.yml
@@ -1,5 +1,7 @@
 # https://kubernetes.io/releases/patch-releases/#detailed-release-history-for-active-branches
 
+- branch: '1.36'
+  end-of-life: '2027-06-28'
 - branch: '1.35'
   end-of-life: '2027-02-28'
 - branch: '1.34'

--- a/compliance-monitor/bootstrap.yaml
+++ b/compliance-monitor/bootstrap.yaml
@@ -93,7 +93,7 @@ accounts:
         public_key_type: "ssh-ed25519"
         public_key_name: "primary"
   - subject: noris-1.33
-    group: noris
+    group: noris-eol
     delegates:
       - zuul_ci
   - subject: noris-1.34
@@ -105,7 +105,7 @@ accounts:
     delegates:
       - zuul_ci
   - subject: scaleup-1.33
-    group: scaleup
+    group: scaleup-eol
     delegates:
       - zuul_ci
   - subject: scaleup-1.34
@@ -117,7 +117,7 @@ accounts:
     delegates:
       - zuul_ci
   - subject: syself-1.33
-    group: syself
+    group: syself-eol
     delegates:
       - zuul_ci
   - subject: syself-1.34


### PR DESCRIPTION
This branch is EOL. Operators may continue to offer it according to the standard.
However, this branch cannot pass the version test, so remove it from the compliance monitor.