### PR TITLE
Certification status in compliance overview

### DIFF
--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -3,66 +3,81 @@ we could of course iterate over results etc., but hardcode the table (except the
 for the time being to have the highest degree of control
 -#}
 
-The following environments are regularly checked for SCS compliance.
+The following tables show environments that are regularly checked for SCS compliance. A distinction is made between certified and non-certified environments. Certified environments are officially certified by the SCS certification assessment body and must maintain compliance throughout the validity period of the certification. Non-certified environments are listed on a voluntary basis to demonstrate their compliance for potential future certification or internal purposes.
 
-Officially certified environments are marked with an X in the “Certified” column and are linked to the respective certification status page.
+The columns "SCS-compatible IaaS"/"SCS-compatible KaaS" show the last compliance status of the environment for the tested scope version. The scope version is suffixed by a symbol depending on the state of the scope: * for _draft_, † for _warn_ (soon to be deprecated), and †† for _deprecated_. Clicking on the compliance status directs to the detailed testing report for the environment.
 
-The scope version numbers in the columns "SCS-compatible IaaS"/"SCS-compatible KaaS" are suffixed by a symbol depending on the state of the scope: * for _draft_, † for _warn_ (soon to be deprecated), and †† for _deprecated_.
+### Certified environments
 
-### SCS-compatible IaaS
+These environments are officially certified by the SCS certification assessment body according to the standard [SCS-0004](https://docs.scs.community/standards/global/scs-0004). Clicking on the name in the first column directs to the official certification status page.
 
-This is a list of IaaS clouds that we test on a nightly basis against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
+#### Certified SCS-compatible IaaS
+
+This is a list of officially certified IaaS environments that are tested regularly against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
 
 {% set iaas = 'scs-compatible-iaas' -%}
-| Name  | Description  | Operator  | Certified  | SCS-compatible IaaS  | HealthMon  |
-|-------|--------------|-----------|------------|----------------------|:----------:|
-| [scs2](https://docs.scs.community/community/cloud-resources/plusserver-gx-scs) | Dev/Test/Demo environment (2nd gen) provided for SCS & GAIA-X context (1 SCS region) | plusserver GmbH | |
-{#- #} [{{ results | pick(iaas, 'scs2') | summary }}]({{ detail_url('scs2', iaas) }}) {# -#}
-| [HM](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&refresh=5m&var-mycmd=All&var-mymethod=All&var-mywait=All&var-mybench=All&var-mycloud=gx-scs2) |
-| [aov.cloud](https://www.aov.de/) | Community cloud for customers (1 SCS region) | aov IT.Services GmbH | |
-{#- #} [{{ results | pick(iaas, 'aov-cloud') | summary }}]({{ detail_url('aov-cloud', iaas) }}) {# -#}
-| [HM](https://health.aov.cloud/) |
-| [CC@RRZE](https://cc.rrze.de/) | Community Compute Cloud (CC) for [FAU](https://www.fau.de/) and Bavaria (1 SCS region) | Erlangen National High Performance Computing Center (NHR@FAU) & Regionales Rechenzentrum Erlangen (RRZE) | |
-{#- #} [{{ results | pick(iaas, 'cc-rrze') | summary }}]({{ detail_url('cc-rrze', iaas) }}) {# -#}
-| (soon) |
-| [CNDS](https://cnds.io/) | Public cloud for customers (2 SCS regions) | artcodix GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/cnds-public-cloud/) |
-{#- #} [{{ results | pick(iaas, 'group-artcodix') | summary }}]({{ detail_url('group-artcodix', iaas) }}) {# -#}
-| [HM](https://ohm.muc.cloud.cnds.io/) |
-| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/en/products/cloud-services/infrastructure-as-a-service/) | Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/cloud-heat/) |
+| Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
+|-------|--------------|-----------|----------------------|:----------:|
+| [Cloud&amp;Heat IaaS](https://sovereigncloudstack.org/en/certified-solution/cloud-heat/) | Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
 {#- #} [{{ results | pick(iaas, 'cah-dd8a') | summary }}]({{ detail_url('cah-dd8a', iaas) }}) {# -#}
 | n/a |
+| [CNDS](https://sovereigncloudstack.org/en/certified-solution/cnds-public-cloud/) | Public cloud for customers (2 SCS regions) | artcodix GmbH |
+{#- #} [{{ results | pick(iaas, 'group-artcodix') | summary }}]({{ detail_url('group-artcodix', iaas) }}) {# -#}
+| [HM](https://ohm.muc.cloud.cnds.io/) |
+| [REGIO.cloud](https://sovereigncloudstack.org/en/certified-solution/osism-gmbh/) | Public cloud for customers (1 SCS region) | OSISM GmbH |
+{#- #} [{{ results | pick(iaas, 'regio-a') | summary }}]({{ detail_url('regio-a', iaas) }}) {# -#}
+| [HM](https://apimon.services.regio.digital/public-dashboards/17cf094a47404398a5b8e35a4a3968d4?orgId=1&refresh=5m) |
+| [ScaleUp Open Cloud](https://sovereigncloudstack.org/en/certified-solution/scaleup-technologies-gmbh-co-kg/) | Public cloud for customers (1 SCS region) | ScaleUp Technologies GmbH & Co. KG |
+{#- #} [{{ results | pick(iaas, 'scaleup-occ2') | summary }}]({{ detail_url('scaleup-occ2', iaas) }}) {# -#}
+| [HM](https://health.occ2.scaleup.sovereignit.cloud) |
+{% if unverified -%}
+{# this section is currently empty -#}
+{% endif %}
+
+#### Certified SCS-compatible KaaS
+
+This is a list of officially certified KaaS environments that are tested regularly against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
+
+{% set kaas = 'scs-compatible-kaas' -%}
+| Name  | Description  | Operator  | SCS-compatible KaaS  |
+|-------|--------------|-----------|----------------------|
+| [noris Sovereign Cloud (nSC)](https://sovereigncloudstack.org/en/certified-solution/noris-network-ag/) | Public KaaS cloud based on Gardener (1 SCS configuration) | noris network AG
+{#- #} [{{ results | pick(kaas, 'group-noris') | summary }}]({{ detail_url('group-noris', kaas) }}) {# -#}
+|
+| [ScaleUp Open Cloud](https://sovereigncloudstack.org/en/certified-solution/scaleup-open-cloud/) | Public KaaS cloud based on Gardener (1 SCS configuration) | ScaleUp Technologies GmbH & Co. KG
+{#- #} [{{ results | pick(kaas, 'group-scaleup') | summary }}]({{ detail_url('group-scaleup', kaas) }}) {# -#}
+|
+| [Syself Autopilot](https://sovereigncloudstack.org/en/certified-solution/syself-gmbh/) | KaaS offering based on ClusterStacks (1 SCS configuration) | Syself GmbH
+{#- #} [{{ results | pick(kaas, 'group-syself') | summary }}]({{ detail_url('group-syself', kaas) }}) {# -#}
+|
+
+### Non-certified environments
+
+#### SCS-compliant IaaS
+
+This is a list of IaaS environments that are tested regularly against the scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/). The environments are not officially certified, however, operators voluntarily make them available for checking their compliance.
+
+{% set iaas = 'scs-compatible-iaas' -%}
+| Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
+|-------|--------------|-----------|----------------------|:----------:|
+| [aov.cloud](https://www.aov.de/) | Community cloud for customers (1 SCS region) | aov IT.Services GmbH |
+{#- #} [{{ results | pick(iaas, 'aov-cloud') | summary }}]({{ detail_url('aov-cloud', iaas) }}) {# -#}
+| [HM](https://health.aov.cloud/) |
+| [CC@RRZE](https://cc.rrze.de/) | Community Compute Cloud (CC) for [FAU](https://www.fau.de/) and Bavaria (1 SCS region) | Erlangen National High Performance Computing Center (NHR@FAU) & Regionales Rechenzentrum Erlangen (RRZE) |
+{#- #} [{{ results | pick(iaas, 'cc-rrze') | summary }}]({{ detail_url('cc-rrze', iaas) }}) {# -#}
+| (soon) |
 | [noris Sovereign Cloud (nSC)](https://www.noris.de/en/it-services/cloud-services/cloud-solutions-for-enterprise-companies/noris-sovereign-cloud/) | Public cloud for customers (1 SCS region) | noris network AG |
 {#- #} [{{ results | pick(iaas, 'nsc-iaas') | summary }}]({{ detail_url('nsc-iaas', iaas) }}) {# -#}
 | [HM](https://healthmon.infra.noris.cloud/d/9ltTEmlnk/openstack-health-monitor-noris-nsc-region-nbg?var-mycloud=nsc) |
-| [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 SCS regions) | plusserver GmbH | |
-{#- #} [{{ results | pick(iaas, 'group-pco-prod') | summary }}]({{ detail_url('group-pco-prod', iaas) }}) {# -#}
+| [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 SCS regions) | plusserver GmbH |
+{#- #}[{{ results | pick(iaas, 'group-pco-prod') | summary }}]({{ detail_url('group-pco-prod', iaas) }}) {# -#}
 | [HM1](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-pco) [HM2](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod2) [HM3](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod3) [HM4](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod4) |
-| [REGIO.cloud](https://regio.digital) | Public cloud for customers (1 SCS region) | OSISM GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/osism-gmbh/) |
-{#- #} [{{ results | pick(iaas, 'regio-a') | summary }}]({{ detail_url('regio-a', iaas) }}) {# -#}
-| [HM](https://apimon.services.regio.digital/public-dashboards/17cf094a47404398a5b8e35a4a3968d4?orgId=1&refresh=5m) |
-| [ScaleUp Open Cloud](https://www.scaleuptech.com/cloud-hosting/) | Public cloud for customers (1 SCS region) | ScaleUp Technologies GmbH & Co. KG | [X](https://sovereigncloudstack.org/en/certified-solution/scaleup-technologies-gmbh-co-kg/) |
-{#- #} [{{ results | pick(iaas, 'scaleup-occ2') | summary }}]({{ detail_url('scaleup-occ2', iaas) }}) {# -#}
-| [HM](https://health.occ2.scaleup.sovereignit.cloud) |
-| [syseleven](https://www.syseleven.de/en/products-services/openstack-cloud/) | Public OpenStack Cloud (2 SCS regions) | SysEleven GmbH | |
+| [scs2](https://docs.scs.community/community/cloud-resources/plusserver-gx-scs) | Dev/Test/Demo environment (2nd gen) provided for SCS & GAIA-X context (1 SCS region) | plusserver GmbH |
+{#- #} [{{ results | pick(iaas, 'scs2') | summary }}]({{ detail_url('scs2', iaas) }}) {# -#}
+| [HM](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&refresh=5m&var-mycmd=All&var-mymethod=All&var-mywait=All&var-mybench=All&var-mycloud=gx-scs2) |
+| [syseleven](https://www.syseleven.de/en/products-services/openstack-cloud/) | Public OpenStack Cloud (2 SCS regions) | SysEleven GmbH |
 {#- #} [{{ results | pick(iaas, 'group-syseleven') | summary }}]({{ detail_url('group-syseleven', iaas) }}) {# -#}
 | (soon) |
 {% if unverified -%}
-{# this section currently empty -#}
+{# this section is currently empty -#}
 {% endif %}
-
-### SCS-compatible KaaS
-
-This is a list of KaaS clouds that we test on a nightly basis against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
-
-{% set kaas = 'scs-compatible-kaas' -%}
-| Name  | Description  | Operator  | Certified  | SCS-compatible KaaS  |
-|-------|--------------|-----------|----------------------|
-| [noris Sovereign Cloud (nSC)](https://www.noris.de/en/it-services/cloud-services/cloud-solutions-for-enterprise-companies/noris-sovereign-cloud/) | Public KaaS cloud based on Gardener (1 SCS configuration) | noris network AG | [X](https://sovereigncloudstack.org/en/certified-solution/noris-network-ag/)
-{#- #} [{{ results | pick(kaas, 'group-noris') | summary }}]({{ detail_url('group-noris', kaas) }}) {# -#}
-|
-| [ScaleUp Open Cloud](https://www.scaleuptech.com/cloud-hosting/) | Public KaaS cloud based on Gardener (1 SCS configuration) | ScaleUp Technologies GmbH & Co. KG | [X](https://sovereigncloudstack.org/en/certified-solution/scaleup-open-cloud/)
-{#- #} [{{ results | pick(kaas, 'group-scaleup') | summary }}]({{ detail_url('group-scaleup', kaas) }}) {# -#}
-|
-| [Syself Autopilot](https://syself.com/platform) | KaaS offering based on ClusterStacks (1 SCS configuration) | Syself GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/syself-gmbh/)
-{#- #} [{{ results | pick(kaas, 'group-syself') | summary }}]({{ detail_url('group-syself', kaas) }}) {# -#}
-|

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -3,43 +3,47 @@ we could of course iterate over results etc., but hardcode the table (except the
 for the time being to have the highest degree of control
 -#}
 
-Version numbers are suffixed by a symbol depending on state: * for _draft_, † for _warn_ (soon to be deprecated), and †† for _deprecated_.
+The following environments are regularly checked for SCS compliance.
+
+Officially certified environments are marked with an X in the “Certified” column and are linked to the respective certification status page.
+
+The scope version numbers in the columns "SCS-compatible IaaS"/"SCS-compatible KaaS" are suffixed by a symbol depending on the state of the scope: * for _draft_, † for _warn_ (soon to be deprecated), and †† for _deprecated_.
 
 ### SCS-compatible IaaS
 
 This is a list of IaaS clouds that we test on a nightly basis against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
 
 {% set iaas = 'scs-compatible-iaas' -%}
-| Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
-|-------|--------------|-----------|----------------------|:----------:|
-| [scs2](https://docs.scs.community/community/cloud-resources/plusserver-gx-scs) | Dev/Test/Demo environment (2nd gen) provided for SCS & GAIA-X context | plusserver GmbH | 
+| Name  | Description  | Operator  | Certified  | SCS-compatible IaaS  | HealthMon  |
+|-------|--------------|-----------|------------|----------------------|:----------:|
+| [scs2](https://docs.scs.community/community/cloud-resources/plusserver-gx-scs) | Dev/Test/Demo environment (2nd gen) provided for SCS & GAIA-X context (1 SCS region) | plusserver GmbH | |
 {#- #} [{{ results | pick(iaas, 'scs2') | summary }}]({{ detail_url('scs2', iaas) }}) {# -#}
 | [HM](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&refresh=5m&var-mycmd=All&var-mymethod=All&var-mywait=All&var-mybench=All&var-mycloud=gx-scs2) |
-| [aov.cloud](https://www.aov.de/) | Community cloud for customers | aov IT.Services GmbH |
+| [aov.cloud](https://www.aov.de/) | Community cloud for customers (1 SCS region) | aov IT.Services GmbH | |
 {#- #} [{{ results | pick(iaas, 'aov-cloud') | summary }}]({{ detail_url('aov-cloud', iaas) }}) {# -#}
 | [HM](https://health.aov.cloud/) |
-| [CC@RRZE](https://cc.rrze.de/) | Community Compute Cloud (CC) for [FAU](https://www.fau.de/) and Bavaria | Erlangen National High Performance Computing Center (NHR@FAU) & Regionales Rechenzentrum Erlangen (RRZE) |
+| [CC@RRZE](https://cc.rrze.de/) | Community Compute Cloud (CC) for [FAU](https://www.fau.de/) and Bavaria (1 SCS region) | Erlangen National High Performance Computing Center (NHR@FAU) & Regionales Rechenzentrum Erlangen (RRZE) | |
 {#- #} [{{ results | pick(iaas, 'cc-rrze') | summary }}]({{ detail_url('cc-rrze', iaas) }}) {# -#}
 | (soon) |
-| [CNDS](https://cnds.io/) | Public cloud for customers (2 regions) | artcodix GmbH |
+| [CNDS](https://cnds.io/) | Public cloud for customers (2 SCS regions) | artcodix GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/cnds-public-cloud/) |
 {#- #} [{{ results | pick(iaas, 'group-artcodix') | summary }}]({{ detail_url('group-artcodix', iaas) }}) {# -#}
 | [HM](https://ohm.muc.cloud.cnds.io/) |
-| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/en/products/cloud-services/infrastructure-as-a-service/) | Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
+| [Cloud&amp;Heat IaaS](https://www.cloudandheat.com/en/products/cloud-services/infrastructure-as-a-service/) | Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/cloud-heat/) |
 {#- #} [{{ results | pick(iaas, 'cah-dd8a') | summary }}]({{ detail_url('cah-dd8a', iaas) }}) {# -#}
 | n/a |
 | [noris Sovereign Cloud (nSC)](https://www.noris.de/en/it-services/cloud-services/cloud-solutions-for-enterprise-companies/noris-sovereign-cloud/) | Public cloud for customers (1 SCS region) | noris network AG |
 {#- #} [{{ results | pick(iaas, 'nsc-iaas') | summary }}]({{ detail_url('nsc-iaas', iaas) }}) {# -#}
 | [HM](https://healthmon.infra.noris.cloud/d/9ltTEmlnk/openstack-health-monitor-noris-nsc-region-nbg?var-mycloud=nsc) |
-| [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 regions)  | plusserver GmbH | {# #}
-{#- #}[{{ results | pick(iaas, 'group-pco-prod') | summary }}]({{ detail_url('group-pco-prod', iaas) }}) {# -#}
+| [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 SCS regions) | plusserver GmbH | |
+{#- #} [{{ results | pick(iaas, 'group-pco-prod') | summary }}]({{ detail_url('group-pco-prod', iaas) }}) {# -#}
 | [HM1](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-pco) [HM2](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod2) [HM3](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod3) [HM4](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod4) |
-| [REGIO.cloud](https://regio.digital) | Public cloud for customers | OSISM GmbH |
+| [REGIO.cloud](https://regio.digital) | Public cloud for customers (1 SCS region) | OSISM GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/osism-gmbh/) |
 {#- #} [{{ results | pick(iaas, 'regio-a') | summary }}]({{ detail_url('regio-a', iaas) }}) {# -#}
 | [HM](https://apimon.services.regio.digital/public-dashboards/17cf094a47404398a5b8e35a4a3968d4?orgId=1&refresh=5m) |
-| [ScaleUp Open Cloud](https://www.scaleuptech.com/cloud-hosting/) | Public cloud for customers | ScaleUp Technologies GmbH & Co. KG |
+| [ScaleUp Open Cloud](https://www.scaleuptech.com/cloud-hosting/) | Public cloud for customers (1 SCS region) | ScaleUp Technologies GmbH & Co. KG | [X](https://sovereigncloudstack.org/en/certified-solution/scaleup-technologies-gmbh-co-kg/) |
 {#- #} [{{ results | pick(iaas, 'scaleup-occ2') | summary }}]({{ detail_url('scaleup-occ2', iaas) }}) {# -#}
 | [HM](https://health.occ2.scaleup.sovereignit.cloud) |
-| [syseleven](https://www.syseleven.de/en/products-services/openstack-cloud/) | Public OpenStack Cloud (2 SCS regions) | SysEleven GmbH | {# #}
+| [syseleven](https://www.syseleven.de/en/products-services/openstack-cloud/) | Public OpenStack Cloud (2 SCS regions) | SysEleven GmbH | |
 {#- #} [{{ results | pick(iaas, 'group-syseleven') | summary }}]({{ detail_url('group-syseleven', iaas) }}) {# -#}
 | (soon) |
 {% if unverified -%}
@@ -51,14 +55,14 @@ This is a list of IaaS clouds that we test on a nightly basis against the certif
 This is a list of KaaS clouds that we test on a nightly basis against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
 
 {% set kaas = 'scs-compatible-kaas' -%}
-| Name  | Description  | Operator  | SCS-compatible KaaS  |
+| Name  | Description  | Operator  | Certified  | SCS-compatible KaaS  |
 |-------|--------------|-----------|----------------------|
-| [noris Sovereign Cloud (nSC)](https://www.noris.de/en/it-services/cloud-services/cloud-solutions-for-enterprise-companies/noris-sovereign-cloud/) | Public KaaS cloud based on Gardener (1 SCS configuration) | noris network AG | {# #}
+| [noris Sovereign Cloud (nSC)](https://www.noris.de/en/it-services/cloud-services/cloud-solutions-for-enterprise-companies/noris-sovereign-cloud/) | Public KaaS cloud based on Gardener (1 SCS configuration) | noris network AG | [X](https://sovereigncloudstack.org/en/certified-solution/noris-network-ag/)
 {#- #} [{{ results | pick(kaas, 'group-noris') | summary }}]({{ detail_url('group-noris', kaas) }}) {# -#}
 |
-| [ScaleUp Open Cloud](https://www.scaleuptech.com/cloud-hosting/) | Public KaaS cloud based on Gardener | ScaleUp Technologies GmbH & Co. KG | {# #}
+| [ScaleUp Open Cloud](https://www.scaleuptech.com/cloud-hosting/) | Public KaaS cloud based on Gardener (1 SCS configuration) | ScaleUp Technologies GmbH & Co. KG | [X](https://sovereigncloudstack.org/en/certified-solution/scaleup-open-cloud/)
 {#- #} [{{ results | pick(kaas, 'group-scaleup') | summary }}]({{ detail_url('group-scaleup', kaas) }}) {# -#}
 |
-| [Syself Autopilot](https://syself.com/platform) | KaaS offering based on ClusterStacks | Syself GmbH | {# #}
+| [Syself Autopilot](https://syself.com/platform) | KaaS offering based on ClusterStacks (1 SCS configuration) | Syself GmbH | [X](https://sovereigncloudstack.org/en/certified-solution/syself-gmbh/)
 {#- #} [{{ results | pick(kaas, 'group-syself') | summary }}]({{ detail_url('group-syself', kaas) }}) {# -#}
 |

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -3,17 +3,17 @@ we could of course iterate over results etc., but hardcode the table (except the
 for the time being to have the highest degree of control
 -#}
 
-The following tables show environments that are regularly checked for SCS compliance. A distinction is made between certified and non-certified environments. Certified environments are officially certified by the SCS certification assessment body and must maintain compliance throughout the validity period of the certification. Non-certified environments are listed on a voluntary basis to demonstrate their compliance for potential future certification or internal purposes.
+The following tables show environments that are regularly checked for SCS compliance. A distinction is made between certified and non-certified environments. [Certified environments](#certified-environments) are officially approved by the SCS certification assessment body and must maintain compliance throughout the validity period of the certification. [Non-certified environments](#non-certified-environments) are listed on a voluntary basis to demonstrate their compliance for potential future certification or internal purposes.
 
-The columns "SCS-compatible IaaS"/"SCS-compatible KaaS" show the last compliance status of the environment for the tested scope version. The scope version is suffixed by a symbol depending on the state of the scope: * for _draft_, † for _warn_ (soon to be deprecated), and †† for _deprecated_. Clicking on the compliance status directs to the detailed testing report for the environment.
+The columns "SCS-compatible IaaS"/"SCS-compatible KaaS" show the latest compliance status of the environment for the tested scope version. The scope version is suffixed by a symbol depending on the state of the scope: * for _draft_, † for _warning_ (soon to be deprecated), and †† for _deprecated_. Clicking on the compliance status links directly to the detailed testing report for the environment.
 
 ### Certified environments
 
-These environments are officially certified by the SCS certification assessment body according to the standard [SCS-0004](https://docs.scs.community/standards/global/scs-0004). Clicking on the name in the first column directs to the official certification status page.
+These environments are officially approved by the SCS certification assessment body according to the standard [SCS-0004](https://docs.scs.community/standards/global/scs-0004). Clicking on the name in the first column links to the official certification status page.
 
 #### Certified SCS-compatible IaaS
 
-This is a list of officially certified IaaS environments that are tested regularly against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
+This is a list of officially approved IaaS environments that are tested regularly against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
 
 {% set iaas = 'scs-compatible-iaas' -%}
 | Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
@@ -36,7 +36,7 @@ This is a list of officially certified IaaS environments that are tested regular
 
 #### Certified SCS-compatible KaaS
 
-This is a list of officially certified KaaS environments that are tested regularly against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
+This is a list of officially approved KaaS environments that are tested regularly against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
 
 {% set kaas = 'scs-compatible-kaas' -%}
 | Name  | Description  | Operator  | SCS-compatible KaaS  |
@@ -55,7 +55,7 @@ This is a list of officially certified KaaS environments that are tested regular
 
 #### SCS-compliant IaaS
 
-This is a list of IaaS environments that are tested regularly against the scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/). The environments are not officially certified, however, operators voluntarily make them available for checking their compliance.
+This is a list of IaaS environments that are tested regularly against the scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/). Although these environments are not officially certified, operators voluntarily list them to demonstrate their compliance.
 
 {% set iaas = 'scs-compatible-iaas' -%}
 | Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -30,9 +30,6 @@ This is a list of officially approved IaaS environments that are tested regularl
 | [ScaleUp Open Cloud](https://sovereigncloudstack.org/en/certified-solution/scaleup-technologies-gmbh-co-kg/) | Public cloud for customers (1 SCS region) | ScaleUp Technologies GmbH & Co. KG |
 {#- #} [{{ results | pick(iaas, 'scaleup-occ2') | summary }}]({{ detail_url('scaleup-occ2', iaas) }}) {# -#}
 | [HM](https://health.occ2.scaleup.sovereignit.cloud) |
-{% if unverified -%}
-{# this section is currently empty -#}
-{% endif %}
 
 #### Certified SCS-compatible KaaS
 
@@ -76,6 +73,3 @@ This is a list of IaaS environments that are tested regularly against the scope 
 | [syseleven](https://www.syseleven.de/en/products-services/openstack-cloud/) | Public OpenStack Cloud (2 SCS regions) | SysEleven GmbH |
 {#- #} [{{ results | pick(iaas, 'group-syseleven') | summary }}]({{ detail_url('group-syseleven', iaas) }}) {# -#}
 | (soon) |
-{% if unverified -%}
-{# this section is currently empty -#}
-{% endif %}

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -4,17 +4,9 @@ for the time being to have the highest degree of control
 -#}
 {% set iaas = 'scs-compatible-iaas' %}{% set kaas = 'scs-compatible-kaas' -%}
 
-The following tables show environments that are regularly checked for SCS compliance. A distinction is made between certified and non-certified environments. [Certified environments](#certified-environments) are officially approved by the SCS certification assessment body and must maintain compliance throughout the validity period of the certification. [Non-certified environments](#non-certified-environments) are listed on a voluntary basis to demonstrate their compliance for potential future certification or internal purposes.
+### Certified SCS-compatible IaaS
 
-The columns "SCS-compatible IaaS"/"SCS-compatible KaaS" show the latest compliance status of the environment for the tested scope version. The scope version is suffixed by a symbol depending on the state of the scope: * for _draft_, † for _warning_ (soon to be deprecated), and †† for _deprecated_. Clicking on the compliance status links directly to the detailed testing report for the environment.
-
-### Certified environments
-
-These environments are officially approved by the SCS certification assessment body according to the standard [SCS-0004](https://docs.scs.community/standards/global/scs-0004). Clicking on the name in the first column links to the official certification status page.
-
-#### Certified SCS-compatible IaaS
-
-This is a list of officially approved IaaS environments that are tested regularly against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
+These environments are officially certified by the SCS certification assessment body according to [SCS-0004](https://docs.scs.community/standards/global/scs-0004). They are regularly tested against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
 
 | Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
 |-------|--------------|-----------|----------------------|:----------:|
@@ -31,9 +23,9 @@ This is a list of officially approved IaaS environments that are tested regularl
 {#- #} [{{ results | pick(iaas, 'scaleup-occ2') | summary }}]({{ detail_url('scaleup-occ2', iaas) }}) {# -#}
 | [HM](https://health.occ2.scaleup.sovereignit.cloud) |
 
-#### Certified SCS-compatible KaaS
+### Certified SCS-compatible KaaS
 
-This is a list of officially approved KaaS environments that are tested regularly against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
+These environments are officially certified by the SCS certification assessment body according to [SCS-0004](https://docs.scs.community/standards/global/scs-0004). They are regularly tested against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
 
 | Name  | Description  | Operator  | SCS-compatible KaaS  |
 |-------|--------------|-----------|----------------------|
@@ -49,9 +41,7 @@ This is a list of officially approved KaaS environments that are tested regularl
 
 ### Non-certified environments
 
-#### SCS-compliant IaaS
-
-This is a list of IaaS environments that are tested regularly against the scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/). Although these environments are not officially certified, operators voluntarily list them to demonstrate their compliance.
+These environments are not officially certified. Operators voluntarily list them to demonstrate their compliance.
 
 | Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
 |-------|--------------|-----------|----------------------|:----------:|

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -2,6 +2,7 @@
 we could of course iterate over results etc., but hardcode the table (except the actual results, of course)
 for the time being to have the highest degree of control
 -#}
+{% set iaas = 'scs-compatible-iaas' %}{% set kaas = 'scs-compatible-kaas' -%}
 
 The following tables show environments that are regularly checked for SCS compliance. A distinction is made between certified and non-certified environments. [Certified environments](#certified-environments) are officially approved by the SCS certification assessment body and must maintain compliance throughout the validity period of the certification. [Non-certified environments](#non-certified-environments) are listed on a voluntary basis to demonstrate their compliance for potential future certification or internal purposes.
 
@@ -15,7 +16,6 @@ These environments are officially approved by the SCS certification assessment b
 
 This is a list of officially approved IaaS environments that are tested regularly against the certificate scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/).
 
-{% set iaas = 'scs-compatible-iaas' -%}
 | Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
 |-------|--------------|-----------|----------------------|:----------:|
 | [Cloud&amp;Heat IaaS](https://sovereigncloudstack.org/en/certified-solution/cloud-heat/) | Public cloud for customers (1 SCS region) | Cloud&amp;Heat Technologies GmbH |
@@ -38,7 +38,6 @@ This is a list of officially approved IaaS environments that are tested regularl
 
 This is a list of officially approved KaaS environments that are tested regularly against the certificate scope [SCS-compatible KaaS](https://docs.scs.community/standards/scs-compatible-kaas/).
 
-{% set kaas = 'scs-compatible-kaas' -%}
 | Name  | Description  | Operator  | SCS-compatible KaaS  |
 |-------|--------------|-----------|----------------------|
 | [noris Sovereign Cloud (nSC)](https://sovereigncloudstack.org/en/certified-solution/noris-network-ag/) | Public KaaS cloud based on Gardener (1 SCS configuration) | noris network AG |
@@ -57,7 +56,6 @@ This is a list of officially approved KaaS environments that are tested regularl
 
 This is a list of IaaS environments that are tested regularly against the scope [SCS-compatible IaaS](https://docs.scs.community/standards/scs-compatible-iaas/). Although these environments are not officially certified, operators voluntarily list them to demonstrate their compliance.
 
-{% set iaas = 'scs-compatible-iaas' -%}
 | Name  | Description  | Operator  | SCS-compatible IaaS  | HealthMon  |
 |-------|--------------|-----------|----------------------|:----------:|
 | [aov.cloud](https://www.aov.de/) | Community cloud for customers (1 SCS region) | aov IT.Services GmbH |

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -41,13 +41,13 @@ This is a list of officially approved KaaS environments that are tested regularl
 {% set kaas = 'scs-compatible-kaas' -%}
 | Name  | Description  | Operator  | SCS-compatible KaaS  |
 |-------|--------------|-----------|----------------------|
-| [noris Sovereign Cloud (nSC)](https://sovereigncloudstack.org/en/certified-solution/noris-network-ag/) | Public KaaS cloud based on Gardener (1 SCS configuration) | noris network AG
+| [noris Sovereign Cloud (nSC)](https://sovereigncloudstack.org/en/certified-solution/noris-network-ag/) | Public KaaS cloud based on Gardener (1 SCS configuration) | noris network AG |
 {#- #} [{{ results | pick(kaas, 'group-noris') | summary }}]({{ detail_url('group-noris', kaas) }}) {# -#}
 |
-| [ScaleUp Open Cloud](https://sovereigncloudstack.org/en/certified-solution/scaleup-open-cloud/) | Public KaaS cloud based on Gardener (1 SCS configuration) | ScaleUp Technologies GmbH & Co. KG
+| [ScaleUp Open Cloud](https://sovereigncloudstack.org/en/certified-solution/scaleup-open-cloud/) | Public KaaS cloud based on Gardener (1 SCS configuration) | ScaleUp Technologies GmbH & Co. KG |
 {#- #} [{{ results | pick(kaas, 'group-scaleup') | summary }}]({{ detail_url('group-scaleup', kaas) }}) {# -#}
 |
-| [Syself Autopilot](https://sovereigncloudstack.org/en/certified-solution/syself-gmbh/) | KaaS offering based on ClusterStacks (1 SCS configuration) | Syself GmbH
+| [Syself Autopilot](https://sovereigncloudstack.org/en/certified-solution/syself-gmbh/) | KaaS offering based on ClusterStacks (1 SCS configuration) | Syself GmbH |
 {#- #} [{{ results | pick(kaas, 'group-syself') | summary }}]({{ detail_url('group-syself', kaas) }}) {# -#}
 |
 

--- a/compliance-monitor/templates/overview.md.j2
+++ b/compliance-monitor/templates/overview.md.j2
@@ -55,7 +55,7 @@ These environments are not officially certified. Operators voluntarily list them
 {#- #} [{{ results | pick(iaas, 'nsc-iaas') | summary }}]({{ detail_url('nsc-iaas', iaas) }}) {# -#}
 | [HM](https://healthmon.infra.noris.cloud/d/9ltTEmlnk/openstack-health-monitor-noris-nsc-region-nbg?var-mycloud=nsc) |
 | [pluscloud open](https://www.plusserver.com/en/products/pluscloud-open) | Public cloud for customers (4 SCS regions) | plusserver GmbH |
-{#- #}[{{ results | pick(iaas, 'group-pco-prod') | summary }}]({{ detail_url('group-pco-prod', iaas) }}) {# -#}
+{#- #} [{{ results | pick(iaas, 'group-pco-prod') | summary }}]({{ detail_url('group-pco-prod', iaas) }}) {# -#}
 | [HM1](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-pco) [HM2](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod2) [HM3](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod3) [HM4](https://health.prod1.plusserver.sovereignit.cloud:3000/d/9ltTEmlnk/openstack-health-monitor2?orgId=1&var-mycloud=plus-prod4) |
 | [scs2](https://docs.scs.community/community/cloud-resources/plusserver-gx-scs) | Dev/Test/Demo environment (2nd gen) provided for SCS & GAIA-X context (1 SCS region) | plusserver GmbH |
 {#- #} [{{ results | pick(iaas, 'scs2') | summary }}]({{ detail_url('scs2', iaas) }}) {# -#}


### PR DESCRIPTION
This PR adds a new column "Certified" with a short explanation to the [compliant cloud environments overview](https://docs.scs.community/standards/certification/overview#compliant-cloud-environments) (aka Compliance Monitor). If an environment is certified, it is also linked to the respective certification status page.

This was discussed in the last Forum SCS-Standards call.

Please (auto)merge if successfully reviewed.