### PR TITLE
SCS-0128: Drop user account lockout test

### DIFF
--- a/Standards/scs-0128-v1-e2e-testing.md
+++ b/Standards/scs-0128-v1-e2e-testing.md
@@ -28,3 +28,18 @@ The end-to-end testing is performed using [Tempest](https://docs.openstack.org/t
 
 The required tests are listed in
 [Tests/iaas/scs_0128_e2e_testing/tempest-tests-non-admin.lst](https://raw.githubusercontent.com/SovereignCloudStack/standards/refs/heads/main/Tests/iaas/scs_0128_e2e_testing/tempest-tests-non-admin.lst).
+
+Tempest MUST NOT report any _failed_ test cases.
+
+## Rationale
+
+In continuation of the original OpenStack-powered Compute, the list of Tempest test cases [was extracted](https://gist.github.com/toothstone/9bf21ea1863ca94da39c0e970f3ad88b#file-refstack-to-tempest-py)
+from [2022.11.json](https://opendev.org/openinfra/interop/src/commit/2a71585700b4141910dbd4139805e2c0e9c49a8e/guidelines/2022.11.json),
+the latest available guidelines file.
+
+The following well-founded alterations were made:
+
+- testcases that require admin privileges were removed in line with general SCS principles,
+- `tempest.api.identity.v3.test_users.IdentityV3UsersTest.test_user_account_lockout` was removed
+  because it is irrelevant in the most common scenario with an external identity provider.
+  ([decision](https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20260723.md))

--- a/Standards/scs-0128-w1-testing-notes.md
+++ b/Standards/scs-0128-w1-testing-notes.md
@@ -21,6 +21,12 @@ SCS conformance tests are expected to be executable without admin privileges (se
 [Regulations for achieving SCS-compatible certification](https://docs.scs.community/standards/scs-0004-v1-achieving-certification#regulations)).
 The list of test cases stated in the standard has been curated accordingly.
 
+### Errata for specific test cases
+
+- `tempest.api.identity.v3.test_users.IdentityV3UsersTest.test_user_account_lockout` was removed upon consensus in the
+[SIG Standardization](https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20260723.md)
+that it is irrelevant, especially when an external identity provider is used
+
 ## How to run Tempest against your cluster
 
 _TODO_ provide step-by-step walkthrough here

--- a/Standards/scs-0128-w1-testing-notes.md
+++ b/Standards/scs-0128-w1-testing-notes.md
@@ -21,12 +21,6 @@ SCS conformance tests are expected to be executable without admin privileges (se
 [Regulations for achieving SCS-compatible certification](https://docs.scs.community/standards/scs-0004-v1-achieving-certification#regulations)).
 The list of test cases stated in the standard has been curated accordingly.
 
-### Errata for specific test cases
-
-- `tempest.api.identity.v3.test_users.IdentityV3UsersTest.test_user_account_lockout` was removed upon consensus in the
-[SIG Standardization](https://github.com/SovereignCloudStack/minutes/blob/main/sig-standardization/20260723.md)
-that it is irrelevant, especially when an external identity provider is used
-
 ## How to run Tempest against your cluster
 
 _TODO_ provide step-by-step walkthrough here

--- a/Tests/iaas/scs_0128_e2e_testing/tempest-tests-non-admin.lst
+++ b/Tests/iaas/scs_0128_e2e_testing/tempest-tests-non-admin.lst
@@ -101,7 +101,6 @@ tempest.api.identity.v3.test_tokens.TokensV3Test.test_create_token[id-6f8e4436-f
 tempest.api.identity.v3.test_tokens.TokensV3Test.test_token_auth_creation_existence_deletion[id-0f9f5a5f-d5cd-4a86-8a5b-c5ded151f212]
 tempest.api.identity.v3.test_tokens.TokensV3Test.test_validate_token[id-a9512ac3-3909-48a4-b395-11f438e16260]
 tempest.api.identity.v3.test_users.IdentityV3UsersTest.test_password_history_check_self_service_api[id-941784ee-5342-4571-959b-b80dd2cea516]
-tempest.api.identity.v3.test_users.IdentityV3UsersTest.test_user_account_lockout[id-a7ad8bbf-2cff-4520-8c1d-96332e151658]
 tempest.api.identity.v3.test_users.IdentityV3UsersTest.test_user_update_own_password[id-ad71bd23-12ad-426b-bb8b-195d2b635f27]
 tempest.api.image.v2.test_images.BasicOperationsImagesTest.test_delete_image[id-f848bb94-1c6e-45a4-8726-39e3a5b23535,smoke]
 tempest.api.image.v2.test_images.BasicOperationsImagesTest.test_register_upload_get_image_file[id-139b765e-7f3d-4b3d-8b37-3ca3876ee318,smoke]


### PR DESCRIPTION
It's not standardized how CSPs are expected to handle this, so we shouldn't test for it.