### PR TITLE
scs-0104: fix dead openstack-image-manager doc link

### DIFF
--- a/Standards/scs-0104-w1-standard-images-implementation.md
+++ b/Standards/scs-0104-w1-standard-images-implementation.md
@@ -57,7 +57,7 @@ Run the test script on your environment and check the error messages :)
 
 The [openstack-image-manager](https://github.com/osism/openstack-image-manager) is able to
 create all standard, mandatory SCS images for you given image definitions from a YAML file.
-Please see [its documentation](https://docs.scs.community/docs/iaas/components/image-manager/) for details.
+Please see [its documentation](https://osism.tech/docs/guides/operations-guide/openstack/tools/image-manager) for details.
 
 ## Automated tests
 


### PR DESCRIPTION
## What

The implementation notes for scs-0104 (`Standards/scs-0104-w1-standard-images-implementation.md`) link to the openstack-image-manager documentation at `docs.scs.community/docs/iaas/components/image-manager/`.

`SovereignCloudStack/docs` recently [stopped mirroring the OSISM IaaS component trees](https://github.com/SovereignCloudStack/docs/commit/4b436a0cc324536c662b952a5df5ebe2cd7bebf0) from `osism.github.io`, so that page no longer exists on the SCS docs site and the link now returns a **404**.

## Change

Repoint it to the authoritative OSISM documentation on `osism.tech`, where the Image Manager tool is now documented:

`https://osism.tech/docs/guides/operations-guide/openstack/tools/image-manager` (verified to resolve, HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)