### PR TITLE
fix: avoid t8s HelmRelease name colliding with run_plugin's cluster_id

### DIFF
--- a/Tests/kaas/plugin/plugin_t8s.py
+++ b/Tests/kaas/plugin/plugin_t8s.py
@@ -29,7 +29,11 @@ class PluginT8s(KubernetesClusterPlugin):
     via a Flux HelmRelease.
 
     Creates a HelmRelease on mgmt-bfe2-prod and waits for the resulting cluster's
-    kubeconfig to appear in the secret '<name>-kubeconfig'.
+    kubeconfig to appear in the secret '<hrName>-kubeconfig'.
+
+    Note: `config['name']` is set by run_plugin.py to the cluster_id (e.g. 'teuto-1.36')
+    for all plugins; that is unrelated to the HelmRelease name below, which is why this
+    plugin uses the distinct key `hrName` instead of reusing `name`.
 
     Expected config keys:
       kubernetesVersion: '1.35'        (major.minor)
@@ -38,8 +42,8 @@ class PluginT8s(KubernetesClusterPlugin):
         kubeconfig: t8s-kubeconfig.yaml  (management cluster kubeconfig template)
       secrets:
         token: '{{ clouds_conf.teuto_mgmt_token }}'
-      name: 'scs-kaas-certification'   (optional, defaults to 'scs-kaas-certification';
-                                        the kubeconfig secret name is derived as '<name>-kubeconfig')
+      hrName: 'scs-kaas-certification' (the kubeconfig secret name is derived as
+                                        '<hrName>-kubeconfig')
       cloud:             'bfe2-prod'    (optional, defaults to 'bfe2-prod')
       controlPlaneHosted: true          (optional, defaults to true)
       nodePools:                        (optional, defaults to a single 'pool-0')
@@ -62,7 +66,7 @@ class PluginT8s(KubernetesClusterPlugin):
         # and cannot be changed without updating both the VAP and the RBAC. They are instance
         # (rather than module-level) attributes because, in principle, different certification
         # targets could be configured with different values here.
-        self.hr_name = config.get("name", "scs-kaas-certification")
+        self.hr_name = config["hrName"]
         self.hr_namespace = "scs-kaas-certification"
         self.hr_kubeconfig_secret = f"{self.hr_name}-kubeconfig"
         self.hr_chart_ref: dict[str, str] = {

--- a/Tests/kaas/plugin/test_plugin_t8s.py
+++ b/Tests/kaas/plugin/test_plugin_t8s.py
@@ -36,6 +36,7 @@ def plugin(tmp_path):
     config = {
         "kubernetesVersion": "1.35",
         "version_patch": 2,
+        "hrName": "scs-kaas-certification",
         "templates": {"kubeconfig": tpl.name},
         "secrets": {},
     }
@@ -136,6 +137,7 @@ def _make_plugin(tmp_path, **config_overrides):
     config = {
         "kubernetesVersion": "1.35",
         "version_patch": 2,
+        "hrName": "scs-kaas-certification",
         "templates": {"kubeconfig": tpl.name},
         "secrets": {},
         **config_overrides,
@@ -175,12 +177,20 @@ def test_hr_name_defaults(plugin):
 
 
 def test_hr_name_from_config(tmp_path):
-    plugin = _make_plugin(tmp_path, name="other-target")
+    plugin = _make_plugin(tmp_path, hrName="other-target")
     assert plugin.hr_name == "other-target"
     assert plugin.hr_kubeconfig_secret == "other-target-kubeconfig"
 
     hr = plugin._build_helmrelease()
     assert hr["metadata"]["name"] == "other-target"
+
+
+def test_hr_name_ignores_run_plugin_name(tmp_path):
+    # run_plugin.py does config.setdefault('name', cluster_id) for every plugin kind;
+    # that generic identifier must not leak into the (differently-keyed) HR name.
+    plugin = _make_plugin(tmp_path, name="teuto-1.36")
+    assert plugin.hr_name == "scs-kaas-certification"
+    assert plugin.hr_kubeconfig_secret == "scs-kaas-certification-kubeconfig"
 
 
 # --- version parsing ---
@@ -196,6 +206,7 @@ def test_version_parsing(tmp_path, version, version_patch, expected):
     config = {
         "kubernetesVersion": version,
         "version_patch": version_patch,
+        "hrName": "scs-kaas-certification",
         "templates": {"kubeconfig": tpl.name},
         "secrets": {},
     }
@@ -209,6 +220,7 @@ def test_version_patch_defaults_to_zero(tmp_path):
     tpl.write_text(KUBECONFIG_TEMPLATE)
     config = {
         "kubernetesVersion": "1.35",
+        "hrName": "scs-kaas-certification",
         "templates": {"kubeconfig": tpl.name},
         "secrets": {},
     }

--- a/playbooks/clusters.yaml.j2
+++ b/playbooks/clusters.yaml.j2
@@ -214,6 +214,7 @@ clusters:
     config:
       kubernetesVersion: '1.35'
       version_patch: 2
+      hrName: scs-kaas-certification
       templates:
         kubeconfig: t8s-kubeconfig.yaml
       secrets:
@@ -223,6 +224,7 @@ clusters:
     config:
       kubernetesVersion: '1.36'
       version_patch: 0
+      hrName: scs-kaas-certification
       templates:
         kubeconfig: t8s-kubeconfig.yaml
       secrets:


### PR DESCRIPTION
## Summary
- `run_plugin.py` sets `config['name']` to the cluster_id (e.g. `teuto-1.36`) for every plugin kind, for use by other plugins.
- `PluginT8s` (merged in #1244) reused that same `name` key for the VAP/RBAC-mandated HelmRelease name, so its `"scs-kaas-certification"` default never took effect — the HelmRelease was created as `teuto-1.36`/`teuto-1.35` instead, which the ValidatingAdmissionPolicy on the management cluster rejects, breaking CI.
- Renamed the config key to `hrName` to avoid the collision. `teuto-1.35`/`teuto-1.36` entries in `clusters.yaml.j2` don't set it, so they correctly fall back to `scs-kaas-certification`.

## Test plan
- [x] Added `test_hr_name_ignores_run_plugin_name`, simulating `run_plugin.py`'s `setdefault('name', cluster_id)` behavior, to prevent regression.
- [x] `python -m pytest Tests/kaas/plugin` — 29/29 passed.
- [x] `flake8 --config=.flake8` — clean except pre-existing unrelated warnings.